### PR TITLE
feat: auto advance environment to controlled turns

### DIFF
--- a/cof_core.pro
+++ b/cof_core.pro
@@ -58,3 +58,18 @@ SOURCES += 	main.cpp \
             game/src/core/map_file.cpp \
             game/src/core/town.cpp
 
+HEADERS += game/src/rl/battle_sim.h \
+           game/src/rl/battle_session.h \
+           game/src/rl/battle_python_bindings.h
+SOURCES += game/src/rl/battle_sim.cpp \
+           game/src/rl/battle_session.cpp \
+           game/src/rl/battle_python_bindings.cpp
+
+LIBCOF_TARGET = $$OUT_PWD/libcof_core.so
+
+libcof_core.target = $$LIBCOF_TARGET
+libcof_core.depends = $(OBJECTS)
+libcof_core.commands = $$QMAKE_CXX -shared -o $$LIBCOF_TARGET $(OBJECTS) $(LIBS)
+
+QMAKE_EXTRA_TARGETS += libcof_core
+POST_TARGETDEPS += $$LIBCOF_TARGET

--- a/docs/rl_combat/combat_audit.md
+++ b/docs/rl_combat/combat_audit.md
@@ -1,0 +1,64 @@
+# Combat Engine Audit Overview
+
+This document summarizes the current combat engine structures and entry points that must be wrapped to create a reinforcement-learning (RL) environment dedicated to battlefield encounters.
+
+## Key Source Files
+- `game/src/core/battlefield.h` / `.cpp`: primary combat state container (`battlefield_t`), action definitions, combat loop utilities, spell/damage resolution, and serialization helpers.
+- `game/src/core/battlefield_hex_grid.h`: hex-grid geometry, neighborhood queries, and coordinate conversions used by movement and range calculations.
+- `game/src/core/ai_combat.cpp`: scripted AI utilities for controlling units (future reference for baseline behaviors).
+- `game/src/core/hero.h`, `troop.h`, `spell.h`, `artifact.h`: hero and unit stats, spell metadata, and buff definitions referenced throughout combat resolution.
+
+These files have no additional AGENTS guidelines, so all coding conventions follow existing project style.
+
+## Core Data Structures
+
+### `battlefield_unit_t`
+Extends `troop_t` with battlefield-specific state such as `troop_id`, grid coordinates, retaliation counters, per-stack health, resurrection tracking, and status flags for waits, moves, spells, morale, and defender/attacker allegiance.【F:game/src/core/battlefield.h†L38-L112】【F:game/src/core/battlefield.h†L392-L436】  It also embeds a fixed-size `buff_t` array and helper methods (`is_disabled`, `is_two_hex`, `is_flyer`, etc.) that enforce ability and status logic used when validating RL actions.
+
+### `battle_action_t`
+Represents an atomic combat event emitted through `fn_emit_combat_action`.  It records the acting unit, optional source/target hexes, movement route, list of affected units (with damage, kills, and healing flags), spell or buff metadata, artifacts/talents applied, wall-section hits, and luck modifiers.【F:game/src/core/battlefield.h†L205-L239】  Serialization helpers in `battlefield.cpp` allow saving/loading action logs for replay datasets.【F:game/src/core/battlefield.cpp†L10-L103】
+
+### `battlefield_hex_grid_t`
+Owns the hex array backing the battlefield and implements axial/offset conversions, distance checks, neighborhood queries, and pixel-mapping helpers.【F:game/src/core/battlefield_hex_grid.h†L1-L124】  Movement validation and pathfinding rely on this API, so the RL wrapper can query legal moves via the same utilities.
+
+### `battlefield_t`
+The central combat state machine storing armies, heroes, environment flags, siege wall health, time dilation effects, accumulated combat stats, and the unit move queue.【F:game/src/core/battlefield.h†L392-L520】  Its methods span combat initialization (`init_hero_*_battle`), spellcasting, movement, attacks, morale checks, queue recomputation, and battle termination.  Most RL-facing APIs will delegate to these methods to ensure parity with the in-game rules.
+
+## Combat Loop Entry Points
+
+### Initialization
+Combat setup functions populate armies and map objects before calling `start_combat()`, which handles artifact-triggered pre-battle spellcasts and seeds the first active unit via `compute_next_unit_to_move()`.【F:game/src/core/battlefield.cpp†L2308-L2366】  During setup, each unit receives a unique `troop_id` used throughout serialization and action logs, so RL observations must preserve this mapping.
+
+### Turn Selection
+`compute_next_unit_to_move()` repeatedly calls `recompute_unit_move_queue()` until it finds a controllable unit or processes auto-resolved entities (catapults, turrets, ballistae).【F:game/src/core/battlefield.cpp†L3224-L3296】  The queue builder groups attacker/defender units, respects wait actions, and interleaves future rounds until it accumulates `BATTLE_QUEUE_DEPTH` entries.【F:game/src/core/battlefield.cpp†L3304-L3389】  This is the natural hook for the RL `step()` routine to fetch the pending actor.
+
+### Action Resolution
+Movement flows through `move_unit()` and optionally triggers morale-based extra turns or `finish_troop_action()` when the action completes.【F:game/src/core/battlefield.cpp†L3389-L3479】  Attacks call `attack_unit()` / `move_and_attack_unit()`, which in turn invoke damage, retaliation, AOE handling, post-attack effects, and action emission.【F:game/src/core/battlefield.cpp†L3609-L3773】【F:game/src/core/battlefield.cpp†L3774-L3962】  Spells route through `cast_spell()` and related helpers (not detailed here) but follow the same `battle_action_t` emission pattern.
+
+### Combat Advancement
+`update_battle()` advances the encounter by repeatedly selecting the active unit, yielding to human players, and otherwise letting the AI automation resolve the turn before checking for completion through `end_combat()`.【F:game/src/core/battlefield.h†L474-L520】【F:game/src/core/battlefield.cpp†L2869-L2888】【F:game/src/core/battlefield.cpp†L3240-L3264】  The loop keeps returning `BATTLE_IN_PROGRESS` until either side runs out of units or the caller requests a single-step advance.
+
+### `update_battle` Control Flow
+When the active unit is AI-controlled, `auto_move_troop()` orchestrates targeting, pathing, attacks, and fallback actions before chaining into queue recomputation helpers.【F:game/src/core/battlefield.cpp†L2890-L3035】  The relationships among the primary helpers are summarized below to guide RL interception points.
+
+```
+update_battle
+  └── auto_move_troop
+        ├── get_nearest_target / get_target_in_range
+        ├── move_and_attack_unit → attack_unit → resolve_damage / retaliation
+        ├── move_unit → finish_troop_action → compute_next_unit_to_move → recompute_unit_move_queue → next_round
+        ├── defend_unit / wait_unit
+        └── catapult/turret/ballista auto-fire → compute_next_unit_to_move
+```
+
+`compute_next_unit_to_move()` also handles morale checks, siege engine automation, and re-entry into the loop when auto-actions finish, so an RL wrapper can either supply a `battle_action_t` directly or let these helpers run for scripted entities.【F:game/src/core/battlefield.cpp†L3058-L3315】  Preserving the queue recomputation logic ensures the environment remains consistent with in-game turn ordering.
+
+### Spell Resolution Touchpoints
+Pre-battle effects and artifact triggers share `cast_spell_on_random_troops()` to pick affected stacks, while interactive hero casting flows through `cast_spell()` with optional unit and hex parameters before emitting `battle_action_t` payloads.【F:game/src/core/battlefield.cpp†L1382-L1426】【F:game/src/core/battlefield.cpp†L2319-L2358】  Both paths eventually call `fn_emit_combat_action`, making them important hooks for logging and for exposing buff changes in RL observations.
+
+## Next Steps
+- Implement the observation encoder and action translator defined in the environment design document, reusing combat serialization helpers.
+- Build the reinforcement-learning environment wrapper around `update_battle()` with reset/step APIs and deterministic seeding.
+- Prototype a lightweight harness that instantiates `battlefield_t`, seeds armies, and exercises `compute_next_unit_to_move()` to confirm we can drive battles without the full game loop.
+
+This foundation captures the primary combat data flow required to wrap the engine in an RL environment while maintaining compatibility with existing mechanics.

--- a/docs/rl_combat/environment_design.md
+++ b/docs/rl_combat/environment_design.md
@@ -1,0 +1,131 @@
+# RL Combat Environment Design
+
+This document specifies the observation, action, reward, and orchestration scaffolding required to train a Deep Q-Network agent for the standalone combat mode.  It builds on the combat audit to ensure the wrapper stays aligned with the in-game rules.
+
+## Environment Goals
+
+- Mirror the native combat state transitions and `battle_action_t` semantics so trained policies remain valid inside the full game.
+- Support self-play by swapping attacker/defender roles across episodes and allowing simultaneous learning/evaluation loops.
+- Provide deterministic resets by reusing existing army/hero generators with explicit RNG seeds.
+- Surface detailed logging (actions, RNG seeds, emitted `battle_action_t` records) for replay inspection and debugging.
+
+## Observation Specification
+
+Observations are a concatenation of global battle metadata, per-hex features, and per-unit attributes.  The layout is designed to plug into convolutional or attention-based encoders.
+
+### Global Features
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| Round number | `battlefield_t::round` | Normalized by `MAX_BATTLE_ROUNDS` |
+| Active side | `battlefield_t::attacker_moved_last` and queue head | Binary attacker/defender flag |
+| Siege metadata | Wall HP, gate status, moat presence | Derived from `castle_layout_t` and `check_wall_section()` state |
+| Hero stats | Primary attributes, morale/luck, mana | Pulled from `hero_t` and `battlefield_t::attacking_hero_*` fields |
+| Spell cooldowns | `attacking_hero_used_cast`, intervals | Track cast availability per hero |
+| Weather/terrain flags | `battlefield_t::is_siege`, `is_quick_combat`, etc. | Provide context for movement penalties |
+
+### Hex Grid Tensor
+
+- Shape: `BATTLEFIELD_WIDTH × BATTLEFIELD_HEIGHT × F_hex`.
+- Features per hex:
+  - Occupancy (empty, attacker unit id, defender unit id).
+  - Passability and moat presence (`battlefield_hex_grid_t::hex::passable`, `is_moat`).
+  - Obstacle type (walls, turrets, towers) encoded as categorical embeddings.
+  - Ranged cover modifier (from `hex_grid.get_ranged_penalty`).
+  - Distance-to-gate for siege attackers (precomputed breadth-first values).
+
+### Per-Unit Table
+
+- Shape: `MAX_TROOPS_PER_SIDE × 2 × F_unit` (attacker and defender slots).
+- Features per unit:
+  - Unit template id (`troop_t::creature_id`).
+  - Current stack size & total HP (derived from `battlefield_unit_t::stack_size`, `hit_points`).
+  - Position (x, y) and facing (for two-hex units).
+  - Action state flags (`has_moved`, `has_waited`, `has_retaliated`, `has_buff(BUFF_BERSERK)`, etc.).
+  - Active buffs/debuffs encoded as multi-hot vector over `buff_e` values.
+  - Ammo count and shots remaining for shooters.
+  - Last action summary (attack, move, defend, wait) from prior `battle_action_t` for temporal context.
+
+### Queue Snapshot
+
+- Include the next `BATTLE_QUEUE_DEPTH` entries with unit ids, remaining wait flags, and round offsets.
+- Provide `time_to_act` scalar for the agent's unit (0 if currently active, positive for queued turns).
+
+## Action Space
+
+Actions are decomposed into a discrete head plus structured parameters to accommodate targeted spells and movement.
+
+### Discrete Action Head
+
+| Index | Meaning | Parameters |
+| --- | --- | --- |
+| 0 | Wait | none |
+| 1 | Defend | none |
+| 2 | Move | Target hex (x, y) |
+| 3 | Melee attack | Target unit id + destination hex |
+| 4 | Ranged attack | Target unit id |
+| 5 | Hero spell | Spell id + optional target hex/unit |
+| 6 | Catapult/turret choice | Wall section or target unit |
+| 7 | Surrender/retreat (if enabled) | confirmation flag |
+
+Invalid combinations are masked using legality checks from `battlefield_t` (e.g., `can_troop_shoot`, `can_troop_act`, `is_spell_cast_allowed`).
+
+### Parameter Encoders
+
+- **Target unit id:** mapped via `battlefield_unit_t::troop_id`; mask unavailable ids.
+- **Target hex:** enumerated over passable hexes; mask unreachable cells using `get_unit_route()` distance checks.
+- **Spell id:** limited to spells known by the casting hero and filtered by mana cost and battlefield conditions.
+- **Wall section:** enumerated via `castle_wall_section_e` with mask when destroyed.
+
+## Reward Shaping
+
+- **Terminal reward:** +1 for victory, -1 for defeat, 0 for stalemate/timeout.
+- **Intermediate signals:**
+  - Scaled damage dealt minus damage taken per action.
+  - Bonuses for eliminating stacks, destroying walls, or capturing siege objectives.
+  - Penalties for illegal actions (should be masked but retained for diagnostics) and idling (e.g., repeated waits when action is available).
+- **Regularization:** Encourage shorter battles by applying a small step penalty after a configurable round threshold.
+
+## Episode Lifecycle
+
+1. **Reset:**
+   - Sample or load attacker/defender armies (JSON templates) and heroes.
+   - Initialize `battlefield_t` through `init_*_battle()` and `start_combat()`.
+   - Serialize the initial `battle_action_t` queue for logging.
+2. **Step:**
+   - Retrieve the current active unit via `get_active_unit()`.
+   - If the unit is agent-controlled, translate the chosen RL action into the appropriate `battlefield_t` method call.
+   - Call `update_battle(game, /*single_step=*/true)` to advance exactly one decision.
+   - Capture emitted `battle_action_t` entries for replay buffers and derive rewards.
+3. **Termination:**
+   - Detect `battle_result_e != BATTLE_IN_PROGRESS` and compute terminal reward.
+   - Return summary stats (units lost, mana spent, wall damage) in the `info` dict.
+
+## Self-Play Orchestration
+
+- Alternate which policy controls attacker vs. defender every episode; allow evaluation matches with fixed scripted AI from `ai_combat.cpp`.
+- Maintain an Elo-style rating or win-rate tracker to select opponents from a league table.
+- Support simultaneous environments for experience generation using battle seeds and asynchronous step calls.
+
+## Tooling and Integration Tasks
+
+1. **C++ Harness Library**
+   - Extract combat initialization and stepping helpers into a small library (`libcof_battle_sim`) exposing C-friendly bindings.
+   - Provide serialization utilities for observations (`battlefield_t` → flat buffer) and actions (flat buffer → `battle_action_t`).
+
+2. **Python Environment Wrapper**
+   - Build a `gymnasium`-compatible interface (`reset`, `step`, `action_space`, `observation_space`).
+   - Implement legal-action masking and epsilon-greedy helper functions for DQN exploration.
+   - Integrate replay buffer writers that store serialized observations and `battle_action_t` logs.
+
+3. **Testing Strategy**
+   - Unit tests covering observation encoding correctness and action application round-trips.
+   - Golden-match regression tests comparing environment outcomes to the native AI for fixed seeds.
+   - Continuous integration job executing smoke battles to validate deterministic resets.
+
+4. **Infrastructure**
+   - Configuration files describing curriculum phases (army sizes, hero levels, siege vs. open field).
+   - Logging hooks exporting `battle_action_t` sequences as JSON/Protobuf for visualization.
+   - Documentation outlining how to extend the action space (e.g., implementing surrender) and how to plug in custom reward functions.
+
+These specifications unblock implementation of the combat RL environment while ensuring compatibility with existing engine mechanics and providing clear testing/integration milestones.

--- a/game/src/core/battlefield.cpp
+++ b/game/src/core/battlefield.cpp
@@ -3100,6 +3100,10 @@ battlefield_unit_t* battlefield_t::get_active_unit() {
 	return (unit_move_queue.size() ? unit_move_queue[0] : nullptr);
 }
 
+const battlefield_unit_t* battlefield_t::get_active_unit() const {
+	return const_cast<battlefield_t*>(this)->get_active_unit();
+}
+
 player_e battlefield_t::get_player_of_active_unit() {
 	player_e player = PLAYER_NONE;
 

--- a/game/src/core/battlefield.h
+++ b/game/src/core/battlefield.h
@@ -510,7 +510,8 @@ struct battlefield_t {
 		
 	void compute_next_unit_to_move();
 	bool recompute_unit_move_queue();
-	battlefield_unit_t* get_active_unit();
+        battlefield_unit_t* get_active_unit();
+        const battlefield_unit_t* get_active_unit() const;
 	player_e get_player_of_active_unit();
 
 	bool is_attackers_turn();

--- a/game/src/rl/battle_python_bindings.cpp
+++ b/game/src/rl/battle_python_bindings.cpp
@@ -1,0 +1,368 @@
+#include "rl/battle_python_bindings.h"
+
+#include "rl/battle_session.h"
+
+#include "core/battlefield.h"
+#include "core/game_config.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace rl {
+namespace combat {
+
+rl_combat_stack_observation_c encode_stack_observation(const battlefield_unit_t& unit) {
+        rl_combat_stack_observation_c output{};
+        output.unit_type = static_cast<uint16_t>(unit.unit_type);
+        output.stack_size = unit.stack_size;
+        output.unit_health = unit.unit_health;
+        output.original_stack_size = unit.original_stack_size;
+        output.retaliations_remaining = unit.retaliations_remaining;
+        output.x = unit.x;
+        output.y = unit.y;
+        output.is_attacker = unit.is_attacker ? 1 : 0;
+        const bool alive = unit.unit_type != UNIT_UNKNOWN && unit.stack_size > 0 && unit.unit_health > 0;
+        output.is_alive = alive ? 1 : 0;
+        output.has_waited = unit.has_waited ? 1 : 0;
+        output.has_moved = unit.has_moved ? 1 : 0;
+        output.has_defended = unit.has_defended ? 1 : 0;
+        output.has_cast_spell = unit.has_cast_spell ? 1 : 0;
+        output.has_moraled = unit.has_moraled ? 1 : 0;
+        output.is_disabled = unit.is_disabled() ? 1 : 0;
+        return output;
+}
+
+hero_loadout_spec_t convert_loadout(const rl_combat_hero_loadout_c& input) {
+        hero_loadout_spec_t output;
+        output.player = static_cast<player_e>(input.player);
+        output.hero_class = static_cast<hero_class_e>(input.hero_class);
+        output.hero_id = input.hero_id;
+        if(input.name)
+                output.name = input.name;
+        output.level = input.level;
+        output.experience = input.experience;
+        output.attack = input.attack;
+        output.defense = input.defense;
+        output.power = input.power;
+        output.knowledge = input.knowledge;
+        output.mana = input.mana;
+        output.dark_energy = input.dark_energy;
+        output.has_ballista = input.has_ballista != 0;
+        output.human_controlled = input.human_controlled != 0;
+
+        for(auto& slot : output.troops)
+                slot = troop_stack_spec_t();
+
+        const size_t troop_limit = std::min(input.troop_count, output.troops.size());
+        if(input.troops) {
+                for(size_t i = 0; i < troop_limit; ++i) {
+                        const auto& troop = input.troops[i];
+                        output.troops[i].unit_type = static_cast<unit_type_e>(troop.unit_type);
+                        output.troops[i].stack_size = troop.stack_size;
+                }
+        }
+
+        output.talents.clear();
+        if(input.talents && input.talent_count > 0) {
+                const size_t capped = std::min(input.talent_count, static_cast<size_t>(game_config::HERO_TALENT_POINTS));
+                output.talents.reserve(capped);
+                for(size_t i = 0; i < capped; ++i)
+                        output.talents.push_back(static_cast<talent_e>(input.talents[i]));
+        }
+
+        output.spellbook.clear();
+        if(input.spells && input.spell_count > 0) {
+                output.spellbook.reserve(input.spell_count);
+                for(size_t i = 0; i < input.spell_count; ++i)
+                        output.spellbook.push_back(static_cast<spell_e>(input.spells[i]));
+        }
+
+        output.enabled_skills.clear();
+        if(input.skills && input.skill_count > 0) {
+                output.enabled_skills.reserve(input.skill_count);
+                for(size_t i = 0; i < input.skill_count; ++i)
+                        output.enabled_skills.push_back(static_cast<skill_e>(input.skills[i]));
+        }
+
+        return output;
+}
+
+battlefield_environment_e clamp_environment(uint8_t environment) {
+        switch(environment) {
+        case BATTLEFIELD_ENVIRONMENT_RANDOM:
+        case BATTLEFIELD_ENVIRONMENT_WATER:
+        case BATTLEFIELD_ENVIRONMENT_GRASS:
+        case BATTLEFIELD_ENVIRONMENT_DIRT:
+        case BATTLEFIELD_ENVIRONMENT_WASTELAND:
+        case BATTLEFIELD_ENVIRONMENT_LAVE:
+        case BATTLEFIELD_ENVIRONMENT_DESERT:
+        case BATTLEFIELD_ENVIRONMENT_BEACH:
+        case BATTLEFIELD_ENVIRONMENT_SNOW:
+        case BATTLEFIELD_ENVIRONMENT_SWAMP:
+        case BATTLEFIELD_ENVIRONMENT_JUNGLE:
+        case BATTLEFIELD_ENVIRONMENT_GRAVEYARD:
+        case BATTLEFIELD_ENVIRONMENT_PYRAMID:
+                return static_cast<battlefield_environment_e>(environment);
+        default:
+                return BATTLEFIELD_ENVIRONMENT_GRASS;
+        }
+}
+
+combat_action_spec_t convert_action(const rl_combat_action_c& input) {
+        combat_action_spec_t output;
+        switch(static_cast<rl_combat_action_type_e>(input.type)) {
+        case RL_COMBAT_ACTION_WAIT:
+                output.type = combat_action_type_t::WAIT;
+                break;
+        case RL_COMBAT_ACTION_DEFEND:
+                output.type = combat_action_type_t::DEFEND;
+                break;
+        case RL_COMBAT_ACTION_AUTO_RESOLVE:
+        default:
+                output.type = combat_action_type_t::AUTO_RESOLVE;
+                break;
+        }
+
+        return output;
+}
+
+} // namespace combat
+} // namespace rl
+
+namespace {
+
+struct game_handle_t {
+        std::unique_ptr<game_t> game_instance;
+};
+
+struct session_handle_t {
+        std::unique_ptr<rl::combat::combat_session_t> session;
+};
+
+} // namespace
+
+extern "C" {
+
+rl_combat_game_handle* rl_combat_create_game() {
+        static std::once_flag config_once;
+        std::call_once(config_once, []() {
+                game_config::load_game_data();
+        });
+
+        auto handle = std::make_unique<game_handle_t>();
+        handle->game_instance = std::make_unique<game_t>();
+        handle->game_instance->game_configuration.player_count = game_config::MAX_NUMBER_OF_PLAYERS;
+        for(size_t i = 0; i < game_config::MAX_NUMBER_OF_PLAYERS; ++i) {
+                auto player_id = static_cast<player_e>(i + 1);
+                auto& config_entry = handle->game_instance->game_configuration.player_configs[i];
+                config_entry.player_number = player_id;
+                config_entry.is_human = false;
+        }
+
+        return reinterpret_cast<rl_combat_game_handle*>(handle.release());
+}
+
+void rl_combat_destroy_game(rl_combat_game_handle* handle) {
+        if(!handle)
+                return;
+
+        auto owned = std::unique_ptr<game_handle_t>(reinterpret_cast<game_handle_t*>(handle));
+        owned.reset();
+}
+
+rl_combat_session_handle* rl_combat_create_session(rl_combat_game_handle* game_handle) {
+        if(!game_handle)
+                return nullptr;
+
+        auto* internal_game = reinterpret_cast<game_handle_t*>(game_handle);
+        if(!internal_game->game_instance)
+                return nullptr;
+
+        auto handle = std::make_unique<session_handle_t>();
+        handle->session = std::make_unique<rl::combat::combat_session_t>(*internal_game->game_instance);
+        return reinterpret_cast<rl_combat_session_handle*>(handle.release());
+}
+
+void rl_combat_destroy_session(rl_combat_session_handle* session_handle) {
+        if(!session_handle)
+                return;
+
+        auto owned = std::unique_ptr<session_handle_t>(reinterpret_cast<session_handle_t*>(session_handle));
+        owned.reset();
+}
+
+int rl_combat_session_configure(rl_combat_session_handle* session_handle, const rl_combat_scenario_c* scenario) {
+        if(!session_handle || !scenario)
+                return -1;
+
+        auto* internal = reinterpret_cast<session_handle_t*>(session_handle);
+        if(!internal->session)
+                return -2;
+
+        rl::combat::combat_scenario_spec_t spec;
+        spec.attacker = rl::combat::convert_loadout(scenario->attacker);
+        spec.defender = rl::combat::convert_loadout(scenario->defender);
+        spec.is_deathmatch = scenario->is_deathmatch != 0;
+        spec.environment = rl::combat::clamp_environment(scenario->environment);
+        spec.quick_combat = scenario->quick_combat != 0;
+
+        internal->session->configure(spec);
+        return 0;
+}
+
+int rl_combat_session_reset(rl_combat_session_handle* session_handle, int* out_result) {
+        if(!session_handle)
+                return -1;
+
+        auto* internal = reinterpret_cast<session_handle_t*>(session_handle);
+        if(!internal->session)
+                return -2;
+
+        auto result = internal->session->reset();
+        if(out_result)
+                *out_result = static_cast<int>(result);
+        return 0;
+}
+
+int rl_combat_session_step(rl_combat_session_handle* session_handle, int* out_result) {
+        if(!session_handle)
+                return -1;
+
+        auto* internal = reinterpret_cast<session_handle_t*>(session_handle);
+        if(!internal->session)
+                return -2;
+
+        auto result = internal->session->step();
+        if(out_result)
+                *out_result = static_cast<int>(result);
+        return 0;
+}
+
+int rl_combat_session_apply_action(rl_combat_session_handle* session_handle, const rl_combat_action_c* action) {
+        if(!session_handle || !action)
+                return -1;
+
+        auto* internal = reinterpret_cast<session_handle_t*>(session_handle);
+        if(!internal->session)
+                return -2;
+
+        auto spec = rl::combat::convert_action(*action);
+        if(!internal->session->apply_action(spec))
+                return -3;
+
+        return 0;
+}
+
+int rl_combat_session_observation(const rl_combat_session_handle* session_handle, rl_combat_observation_c* out_observation) {
+        if(!session_handle || !out_observation)
+                return -1;
+
+        auto* internal = reinterpret_cast<const session_handle_t*>(session_handle);
+        if(!internal->session)
+                return -2;
+
+        std::memset(out_observation, 0, sizeof(*out_observation));
+        out_observation->active_unit_id = -1;
+        out_observation->active_unit_x = -1;
+        out_observation->active_unit_y = -1;
+
+        const auto& session = *internal->session;
+        const auto& battlefield = session.battlefield();
+
+        out_observation->round = static_cast<uint16_t>(std::min(
+                battlefield.round,
+                static_cast<uint>(std::numeric_limits<uint16_t>::max())));
+        out_observation->attacker_moved_last = battlefield.attacker_moved_last ? 1 : 0;
+        out_observation->is_siege = battlefield.is_siege() ? 1 : 0;
+        out_observation->is_quick_combat = battlefield.is_quick_combat ? 1 : 0;
+
+        if(const auto* active_unit = battlefield.get_active_unit()) {
+                out_observation->active_unit_id = active_unit->troop_id;
+                out_observation->active_unit_is_attacker = active_unit->is_attacker ? 1 : 0;
+                out_observation->active_unit_x = active_unit->x;
+                out_observation->active_unit_y = active_unit->y;
+        }
+
+        const auto& attacker = session.attacker();
+        const auto& defender = session.defender();
+        out_observation->attacker_mana = attacker.mana;
+        out_observation->defender_mana = defender.mana;
+        out_observation->attacker_morale = static_cast<int16_t>(attacker.get_morale());
+        out_observation->defender_morale = static_cast<int16_t>(defender.get_morale());
+        out_observation->attacker_luck = static_cast<int16_t>(attacker.get_luck());
+        out_observation->defender_luck = static_cast<int16_t>(defender.get_luck());
+
+        size_t attacker_count = 0;
+        for(const auto& unit : battlefield.attacking_army.troops) {
+                if(unit.unit_type == UNIT_UNKNOWN || unit.stack_size == 0)
+                        continue;
+                if(attacker_count >= RL_COMBAT_MAX_ARMY_TROOPS)
+                        break;
+                out_observation->attacker_stacks[attacker_count++] = rl::combat::encode_stack_observation(unit);
+        }
+        out_observation->attacker_stack_count = static_cast<uint8_t>(attacker_count);
+
+        size_t defender_count = 0;
+        for(const auto& unit : battlefield.defending_army.troops) {
+                if(unit.unit_type == UNIT_UNKNOWN || unit.stack_size == 0)
+                        continue;
+                if(defender_count >= RL_COMBAT_MAX_ARMY_TROOPS)
+                        break;
+                out_observation->defender_stacks[defender_count++] = rl::combat::encode_stack_observation(unit);
+        }
+        out_observation->defender_stack_count = static_cast<uint8_t>(defender_count);
+
+        return 0;
+}
+
+const battlefield_t* rl_combat_session_battlefield(const rl_combat_session_handle* session_handle) {
+        if(!session_handle)
+                return nullptr;
+
+        auto* internal = reinterpret_cast<const session_handle_t*>(session_handle);
+        if(!internal->session)
+                return nullptr;
+
+        return &internal->session->battlefield();
+}
+
+const hero_t* rl_combat_session_attacker(const rl_combat_session_handle* session_handle) {
+        if(!session_handle)
+                return nullptr;
+
+        auto* internal = reinterpret_cast<const session_handle_t*>(session_handle);
+        if(!internal->session)
+                return nullptr;
+
+        return &internal->session->attacker();
+}
+
+const hero_t* rl_combat_session_defender(const rl_combat_session_handle* session_handle) {
+        if(!session_handle)
+                return nullptr;
+
+        auto* internal = reinterpret_cast<const session_handle_t*>(session_handle);
+        if(!internal->session)
+                return nullptr;
+
+        return &internal->session->defender();
+}
+
+const game_t* rl_combat_session_game(const rl_combat_session_handle* session_handle) {
+        if(!session_handle)
+                return nullptr;
+
+        auto* internal = reinterpret_cast<const session_handle_t*>(session_handle);
+        if(!internal->session)
+                return nullptr;
+
+        return &internal->session->game();
+}
+
+} // extern "C"

--- a/game/src/rl/battle_python_bindings.h
+++ b/game/src/rl/battle_python_bindings.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct game_t;
+struct hero_t;
+struct battlefield_t;
+
+enum {
+        RL_COMBAT_MAX_ARMY_TROOPS = 16,
+};
+
+typedef struct rl_combat_game_handle rl_combat_game_handle;
+typedef struct rl_combat_session_handle rl_combat_session_handle;
+
+typedef struct rl_combat_troop_stack_c {
+        uint16_t unit_type;
+        uint16_t stack_size;
+} rl_combat_troop_stack_c;
+
+typedef struct rl_combat_stack_observation_c {
+        uint16_t unit_type;
+        uint16_t stack_size;
+        uint16_t unit_health;
+        uint16_t original_stack_size;
+        int8_t retaliations_remaining;
+        int8_t x;
+        int8_t y;
+        uint8_t is_attacker;
+        uint8_t is_alive;
+        uint8_t has_waited;
+        uint8_t has_moved;
+        uint8_t has_defended;
+        uint8_t has_cast_spell;
+        uint8_t has_moraled;
+        uint8_t is_disabled;
+} rl_combat_stack_observation_c;
+
+typedef struct rl_combat_hero_loadout_c {
+        uint8_t player;
+        uint8_t hero_class;
+        uint16_t hero_id;
+        const char* name;
+        uint8_t level;
+        uint64_t experience;
+        uint8_t attack;
+        uint8_t defense;
+        uint8_t power;
+        uint8_t knowledge;
+        uint16_t mana;
+        uint16_t dark_energy;
+        uint8_t has_ballista;
+        uint8_t human_controlled;
+        const rl_combat_troop_stack_c* troops;
+        size_t troop_count;
+        const uint8_t* talents;
+        size_t talent_count;
+        const uint16_t* spells;
+        size_t spell_count;
+        const uint8_t* skills;
+        size_t skill_count;
+} rl_combat_hero_loadout_c;
+
+typedef struct rl_combat_scenario_c {
+        rl_combat_hero_loadout_c attacker;
+        rl_combat_hero_loadout_c defender;
+        uint8_t is_deathmatch;
+        uint8_t environment;
+        uint8_t quick_combat;
+} rl_combat_scenario_c;
+
+typedef struct rl_combat_observation_c {
+        uint16_t round;
+        uint8_t attacker_moved_last;
+        uint8_t is_siege;
+        uint8_t is_quick_combat;
+        int8_t active_unit_id;
+        uint8_t active_unit_is_attacker;
+        int8_t active_unit_x;
+        int8_t active_unit_y;
+        uint16_t attacker_mana;
+        uint16_t defender_mana;
+        int16_t attacker_morale;
+        int16_t defender_morale;
+        int16_t attacker_luck;
+        int16_t defender_luck;
+        uint8_t attacker_stack_count;
+        uint8_t defender_stack_count;
+        rl_combat_stack_observation_c attacker_stacks[RL_COMBAT_MAX_ARMY_TROOPS];
+        rl_combat_stack_observation_c defender_stacks[RL_COMBAT_MAX_ARMY_TROOPS];
+} rl_combat_observation_c;
+
+typedef enum rl_combat_action_type_e {
+        RL_COMBAT_ACTION_WAIT = 0,
+        RL_COMBAT_ACTION_DEFEND = 1,
+        RL_COMBAT_ACTION_AUTO_RESOLVE = 2,
+} rl_combat_action_type_e;
+
+typedef struct rl_combat_action_c {
+        uint8_t type;
+} rl_combat_action_c;
+
+rl_combat_game_handle* rl_combat_create_game();
+void rl_combat_destroy_game(rl_combat_game_handle* handle);
+
+rl_combat_session_handle* rl_combat_create_session(rl_combat_game_handle* game_handle);
+void rl_combat_destroy_session(rl_combat_session_handle* session_handle);
+
+int rl_combat_session_configure(rl_combat_session_handle* session_handle, const rl_combat_scenario_c* scenario);
+int rl_combat_session_reset(rl_combat_session_handle* session_handle, int* out_result);
+int rl_combat_session_step(rl_combat_session_handle* session_handle, int* out_result);
+int rl_combat_session_apply_action(rl_combat_session_handle* session_handle, const rl_combat_action_c* action);
+
+int rl_combat_session_observation(const rl_combat_session_handle* session_handle, rl_combat_observation_c* out_observation);
+
+const battlefield_t* rl_combat_session_battlefield(const rl_combat_session_handle* session_handle);
+const hero_t* rl_combat_session_attacker(const rl_combat_session_handle* session_handle);
+const hero_t* rl_combat_session_defender(const rl_combat_session_handle* session_handle);
+const game_t* rl_combat_session_game(const rl_combat_session_handle* session_handle);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+

--- a/game/src/rl/battle_session.cpp
+++ b/game/src/rl/battle_session.cpp
@@ -1,0 +1,179 @@
+#include "rl/battle_session.h"
+
+#include <algorithm>
+#include <cassert>
+
+namespace rl {
+namespace combat {
+
+namespace {
+std::vector<player_e> get_unique_human_players(const combat_scenario_spec_t& spec) {
+        std::vector<player_e> humans;
+        if(spec.attacker.human_controlled)
+                humans.push_back(spec.attacker.player);
+        if(spec.defender.human_controlled)
+                humans.push_back(spec.defender.player);
+
+        std::sort(humans.begin(), humans.end(), [] (player_e lhs, player_e rhs) {
+                return static_cast<uint8_t>(lhs) < static_cast<uint8_t>(rhs);
+        });
+        humans.erase(std::unique(humans.begin(), humans.end()), humans.end());
+        return humans;
+}
+
+uint16_t resolve_hero_id(const hero_loadout_spec_t& spec, bool is_attacker) {
+        if(spec.hero_id != 0)
+                return spec.hero_id;
+
+        return static_cast<uint16_t>(is_attacker ? 1 : 2);
+}
+
+std::string resolve_hero_name(const hero_loadout_spec_t& spec, bool is_attacker) {
+        if(!spec.name.empty())
+                return spec.name;
+
+        return is_attacker ? std::string("RL Attacker") : std::string("RL Defender");
+}
+
+} // namespace
+
+combat_session_t::combat_session_t(game_t& game_instance)
+        : simulator(game_instance) {
+}
+
+void combat_session_t::configure(const combat_scenario_spec_t& spec) {
+        scenario_spec = spec;
+        apply_loadout(scenario_spec.attacker, attacker_hero, true);
+        apply_loadout(scenario_spec.defender, defender_hero, false);
+        configure_player_control();
+        scenario_loaded = true;
+}
+
+battle_result_e combat_session_t::reset() {
+        assert(scenario_loaded && "combat_session_t::reset called before configure");
+
+        apply_loadout(scenario_spec.attacker, attacker_hero, true);
+        apply_loadout(scenario_spec.defender, defender_hero, false);
+        configure_player_control();
+
+        auto& battlefield_instance = simulator.battlefield();
+        battlefield_instance.environment_type = scenario_spec.environment;
+        battlefield_instance.is_quick_combat = scenario_spec.quick_combat;
+        battlefield_instance.init_hero_hero_battle(&attacker_hero, &defender_hero, scenario_spec.is_deathmatch);
+        battlefield_instance.start_combat();
+        return BATTLE_IN_PROGRESS;
+}
+
+battle_result_e combat_session_t::reset(const combat_scenario_spec_t& spec) {
+        configure(spec);
+        return reset();
+}
+
+battle_result_e combat_session_t::step() {
+        return simulator.step();
+}
+
+bool combat_session_t::apply_action(const combat_action_spec_t& action) {
+        auto& battlefield_instance = simulator.battlefield();
+        auto* active_unit = battlefield_instance.get_active_unit();
+        if(!active_unit)
+                return false;
+
+        switch(action.type) {
+        case combat_action_type_t::WAIT:
+                return battlefield_instance.wait_unit(active_unit);
+        case combat_action_type_t::DEFEND:
+                return battlefield_instance.defend_unit(active_unit);
+        case combat_action_type_t::AUTO_RESOLVE:
+                return battlefield_instance.auto_move_troop();
+        default:
+                break;
+        }
+
+        return false;
+}
+
+hero_t& combat_session_t::attacker() {
+        return attacker_hero;
+}
+
+const hero_t& combat_session_t::attacker() const {
+        return attacker_hero;
+}
+
+hero_t& combat_session_t::defender() {
+        return defender_hero;
+}
+
+const hero_t& combat_session_t::defender() const {
+        return defender_hero;
+}
+
+battlefield_t& combat_session_t::battlefield() {
+        return simulator.battlefield();
+}
+
+const battlefield_t& combat_session_t::battlefield() const {
+        return simulator.battlefield();
+}
+
+game_t& combat_session_t::game() {
+        return simulator.game();
+}
+
+const game_t& combat_session_t::game() const {
+        return simulator.game();
+}
+
+void combat_session_t::apply_loadout(const hero_loadout_spec_t& spec, hero_t& hero, bool is_attacker) {
+        hero = hero_t();
+        hero.id = resolve_hero_id(spec, is_attacker);
+        hero.player = spec.player;
+        hero.hero_class = spec.hero_class;
+        hero.name = resolve_hero_name(spec, is_attacker);
+        hero.level = spec.level;
+        hero.experience = spec.experience;
+        hero.attack = spec.attack;
+        hero.defense = spec.defense;
+        hero.power = spec.power;
+        hero.knowledge = spec.knowledge;
+        hero.mana = spec.mana;
+        hero.dark_energy = spec.dark_energy;
+        hero.has_ballista = spec.has_ballista;
+        hero.uncontrolled_by_human = !spec.human_controlled;
+
+        apply_troops(spec, hero);
+        apply_talents(spec, hero);
+        apply_spells_and_skills(spec, hero);
+}
+
+void combat_session_t::apply_troops(const hero_loadout_spec_t& spec, hero_t& hero) {
+        hero.troops.fill(troop_t());
+        for(size_t i = 0; i < spec.troops.size(); ++i) {
+                const auto& slot = spec.troops[i];
+                if(slot.unit_type == UNIT_UNKNOWN || slot.stack_size == 0)
+                        continue;
+
+                hero.troops[i] = troop_t(slot.unit_type, slot.stack_size);
+        }
+}
+
+void combat_session_t::apply_talents(const hero_loadout_spec_t& spec, hero_t& hero) {
+        hero.talents.fill(TALENT_NONE);
+        for(size_t i = 0; i < spec.talents.size() && i < hero.talents.size(); ++i)
+                hero.talents[i] = spec.talents[i];
+}
+
+void combat_session_t::apply_spells_and_skills(const hero_loadout_spec_t& spec, hero_t& hero) {
+        hero.spellbook = spec.spellbook;
+        hero.enabled_skills = spec.enabled_skills;
+}
+
+void combat_session_t::configure_player_control() {
+        auto humans = get_unique_human_players(scenario_spec);
+        assign_human_players(game(), humans);
+}
+
+} // namespace combat
+} // namespace rl
+

--- a/game/src/rl/battle_session.h
+++ b/game/src/rl/battle_session.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "rl/battle_sim.h"
+
+#include "core/hero.h"
+#include "core/troop.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace rl {
+namespace combat {
+
+struct troop_stack_spec_t {
+        unit_type_e unit_type = UNIT_UNKNOWN;
+        uint16_t stack_size = 0;
+};
+
+struct hero_loadout_spec_t {
+        player_e player = PLAYER_1;
+        hero_class_e hero_class = HERO_KNIGHT;
+        uint16_t hero_id = 0;
+        std::string name;
+        uint8_t level = 1;
+        uint64_t experience = 0;
+        uint8_t attack = 0;
+        uint8_t defense = 0;
+        uint8_t power = 1;
+        uint8_t knowledge = 1;
+        uint16_t mana = 10;
+        uint16_t dark_energy = 0;
+        bool has_ballista = false;
+        bool human_controlled = true;
+        std::array<troop_stack_spec_t, game_config::HERO_TROOP_SLOTS> troops = {};
+        std::vector<talent_e> talents;
+        std::vector<spell_e> spellbook;
+        std::vector<skill_e> enabled_skills;
+};
+
+struct combat_scenario_spec_t {
+        hero_loadout_spec_t attacker;
+        hero_loadout_spec_t defender;
+        bool is_deathmatch = false;
+        battlefield_environment_e environment = BATTLEFIELD_ENVIRONMENT_GRASS;
+        bool quick_combat = false;
+};
+
+enum class combat_action_type_t : uint8_t {
+        WAIT = 0,
+        DEFEND = 1,
+        AUTO_RESOLVE = 2,
+};
+
+struct combat_action_spec_t {
+        combat_action_type_t type = combat_action_type_t::WAIT;
+};
+
+class combat_session_t {
+public:
+        explicit combat_session_t(game_t& game_instance);
+
+        void configure(const combat_scenario_spec_t& spec);
+        battle_result_e reset();
+        battle_result_e reset(const combat_scenario_spec_t& spec);
+
+        battle_result_e step();
+        bool apply_action(const combat_action_spec_t& action);
+
+        const combat_scenario_spec_t& scenario() const { return scenario_spec; }
+
+        hero_t& attacker();
+        const hero_t& attacker() const;
+        hero_t& defender();
+        const hero_t& defender() const;
+
+        battlefield_t& battlefield();
+        const battlefield_t& battlefield() const;
+
+        game_t& game();
+        const game_t& game() const;
+
+private:
+        void apply_loadout(const hero_loadout_spec_t& spec, hero_t& hero, bool is_attacker);
+        void apply_troops(const hero_loadout_spec_t& spec, hero_t& hero);
+        void apply_talents(const hero_loadout_spec_t& spec, hero_t& hero);
+        void apply_spells_and_skills(const hero_loadout_spec_t& spec, hero_t& hero);
+        void configure_player_control();
+
+        battle_sim_t simulator;
+        combat_scenario_spec_t scenario_spec;
+        hero_t attacker_hero;
+        hero_t defender_hero;
+        bool scenario_loaded = false;
+};
+
+} // namespace combat
+} // namespace rl
+

--- a/game/src/rl/battle_sim.cpp
+++ b/game/src/rl/battle_sim.cpp
@@ -1,0 +1,143 @@
+#include "rl/battle_sim.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace rl {
+namespace combat {
+namespace {
+
+void ensure_player_table(game_t& game_instance) {
+        if(game_instance.players.size() < game_config::MAX_NUMBER_OF_PLAYERS) {
+                game_instance.players.resize(game_config::MAX_NUMBER_OF_PLAYERS);
+        }
+
+        for(uint i = 0; i < game_config::MAX_NUMBER_OF_PLAYERS; ++i) {
+                const auto player_id = static_cast<player_e>(i + 1);
+                auto& player_entry = game_instance.players[i];
+                player_entry.player_number = player_id;
+
+                auto& config_entry = game_instance.game_configuration.player_configs[i];
+                config_entry.player_number = player_id;
+        }
+}
+
+}
+
+battle_sim_t::battle_sim_t(game_t& game_instance) : game_instance(&game_instance) {
+        initialize_players_if_needed();
+        update_emit_callback();
+}
+
+void battle_sim_t::set_options(const battle_sim_options_t& options) {
+        current_options = options;
+        update_emit_callback();
+}
+
+void battle_sim_t::set_single_step(bool single_step) {
+        current_options.single_step = single_step;
+}
+
+void battle_sim_t::set_emit_callback(std::function<void(const battle_action_t&)> callback) {
+        current_options.emit_action = std::move(callback);
+        update_emit_callback();
+}
+
+void battle_sim_t::clear_emit_callback() {
+        current_options.emit_action = nullptr;
+        update_emit_callback();
+}
+
+void battle_sim_t::set_player_control(player_e player, bool is_human) {
+        initialize_players_if_needed();
+
+        if(!game_instance || !game_instance->player_valid(player))
+                return;
+
+        auto& player_entry = game_instance->get_player(player);
+        player_entry.player_number = player;
+        player_entry.is_human = is_human;
+
+        auto index = static_cast<size_t>(player) - 1;
+        auto& config_entry = game_instance->game_configuration.player_configs[index];
+        config_entry.player_number = player;
+        config_entry.is_human = is_human;
+}
+
+void battle_sim_t::set_players_controlled(const std::vector<player_e>& players) {
+        initialize_players_if_needed();
+
+        if(!game_instance)
+                return;
+
+        for(uint i = 0; i < game_config::MAX_NUMBER_OF_PLAYERS; ++i) {
+                const auto player_id = static_cast<player_e>(i + 1);
+                const bool is_human = std::find(players.begin(), players.end(), player_id) != players.end();
+                set_player_control(player_id, is_human);
+        }
+}
+
+battle_result_e battle_sim_t::step() {
+        if(!game_instance)
+                return BATTLE_IN_PROGRESS;
+
+        return game_instance->battle.update_battle(game_instance, current_options.single_step);
+}
+
+battlefield_t& battle_sim_t::battlefield() {
+        return game_instance->battle;
+}
+
+const battlefield_t& battle_sim_t::battlefield() const {
+        return game_instance->battle;
+}
+
+game_t& battle_sim_t::game() {
+        return *game_instance;
+}
+
+const game_t& battle_sim_t::game() const {
+        return *game_instance;
+}
+
+void battle_sim_t::initialize_players_if_needed() {
+        if(!game_instance)
+                return;
+
+        ensure_player_table(*game_instance);
+}
+
+void battle_sim_t::update_emit_callback() {
+        if(!game_instance)
+                return;
+
+        if(current_options.emit_action) {
+                game_instance->battle.fn_emit_combat_action = [this](const battle_action_t& action) {
+                        if(current_options.emit_action)
+                                current_options.emit_action(action);
+                };
+        } else {
+                game_instance->battle.fn_emit_combat_action = [](const battle_action_t&) {};
+        }
+}
+
+void assign_human_players(game_t& game_instance, const std::vector<player_e>& human_players) {
+        ensure_player_table(game_instance);
+
+        for(uint i = 0; i < game_config::MAX_NUMBER_OF_PLAYERS; ++i) {
+                const auto player_id = static_cast<player_e>(i + 1);
+                const bool is_human = std::find(human_players.begin(), human_players.end(), player_id) != human_players.end();
+
+                auto& player_entry = game_instance.players[i];
+                player_entry.player_number = player_id;
+                player_entry.is_human = is_human;
+
+                auto& config_entry = game_instance.game_configuration.player_configs[i];
+                config_entry.player_number = player_id;
+                config_entry.is_human = is_human;
+        }
+}
+
+} // namespace combat
+} // namespace rl
+

--- a/game/src/rl/battle_sim.h
+++ b/game/src/rl/battle_sim.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "core/game.h"
+
+#include <functional>
+#include <vector>
+
+namespace rl {
+namespace combat {
+
+struct battle_sim_options_t {
+        bool single_step = true;
+        std::function<void(const battle_action_t&)> emit_action;
+};
+
+class battle_sim_t {
+public:
+        explicit battle_sim_t(game_t& game_instance);
+
+        void set_options(const battle_sim_options_t& options);
+        void set_single_step(bool single_step);
+        void set_emit_callback(std::function<void(const battle_action_t&)> callback);
+        void clear_emit_callback();
+
+        void set_player_control(player_e player, bool is_human);
+        void set_players_controlled(const std::vector<player_e>& players);
+
+        battle_result_e step();
+
+        battlefield_t& battlefield();
+        const battlefield_t& battlefield() const;
+
+        game_t& game();
+        const game_t& game() const;
+
+private:
+        void initialize_players_if_needed();
+        void update_emit_callback();
+
+        game_t* game_instance = nullptr;
+        battle_sim_options_t current_options;
+};
+
+/// Convenience helper to mark every player as AI-controlled except the ones provided in `human_players`.
+void assign_human_players(game_t& game_instance, const std::vector<player_e>& human_players);
+
+} // namespace combat
+} // namespace rl
+

--- a/python/rl_combat/__init__.py
+++ b/python/rl_combat/__init__.py
@@ -1,0 +1,27 @@
+"""Python bindings for the Clash of Fantasy combat reinforcement-learning scaffolding."""
+
+from . import training
+from .environment import CombatEnvironment, ControlledSide
+from .observation import (EncodedCombatObservation, encode_combat_observation,
+                          flatten_observation)
+from .scenario import CombatScenario, HeroLoadout, TroopStack
+from .session import (BattleResult, CombatAction, CombatActionType,
+                      CombatObservation, CombatSession, StackObservation)
+
+__all__ = [
+        "CombatEnvironment",
+        "BattleResult",
+        "CombatAction",
+        "CombatActionType",
+        "CombatObservation",
+        "CombatScenario",
+        "CombatSession",
+        "ControlledSide",
+        "EncodedCombatObservation",
+        "HeroLoadout",
+        "StackObservation",
+        "TroopStack",
+        "encode_combat_observation",
+        "flatten_observation",
+        "training",
+]

--- a/python/rl_combat/bindings.py
+++ b/python/rl_combat/bindings.py
@@ -1,0 +1,206 @@
+"""Low-level ctypes bindings to the combat session C API."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from ctypes import (c_char_p, c_int, c_int16, c_int8, c_size_t, c_uint8,
+                     c_uint16, c_uint64, c_void_p, POINTER)
+from typing import Iterable, Optional
+
+__all__ = [
+        "BattlefieldPointer",
+        "CombatObservationC",
+        "CombatActionC",
+        "CombatScenarioC",
+        "GameHandle",
+        "HeroLoadoutC",
+        "Library",  # alias for the loaded CDLL
+        "RL_COMBAT_MAX_ARMY_TROOPS",
+        "SessionHandle",
+        "StackObservationC",
+        "TroopStackC",
+        "ensure_library",
+]
+
+Library = ctypes.CDLL
+BattlefieldPointer = c_void_p
+GameHandle = c_void_p
+SessionHandle = c_void_p
+
+RL_COMBAT_MAX_ARMY_TROOPS = 16
+
+
+class TroopStackC(ctypes.Structure):
+        _fields_ = [
+                ("unit_type", c_uint16),
+                ("stack_size", c_uint16),
+        ]
+
+
+class HeroLoadoutC(ctypes.Structure):
+        _fields_ = [
+                ("player", c_uint8),
+                ("hero_class", c_uint8),
+                ("hero_id", c_uint16),
+                ("name", c_char_p),
+                ("level", c_uint8),
+                ("experience", c_uint64),
+                ("attack", c_uint8),
+                ("defense", c_uint8),
+                ("power", c_uint8),
+                ("knowledge", c_uint8),
+                ("mana", c_uint16),
+                ("dark_energy", c_uint16),
+                ("has_ballista", c_uint8),
+                ("human_controlled", c_uint8),
+                ("troops", POINTER(TroopStackC)),
+                ("troop_count", c_size_t),
+                ("talents", POINTER(c_uint8)),
+                ("talent_count", c_size_t),
+                ("spells", POINTER(c_uint16)),
+                ("spell_count", c_size_t),
+                ("skills", POINTER(c_uint8)),
+                ("skill_count", c_size_t),
+        ]
+
+
+class CombatScenarioC(ctypes.Structure):
+        _fields_ = [
+                ("attacker", HeroLoadoutC),
+                ("defender", HeroLoadoutC),
+                ("is_deathmatch", c_uint8),
+                ("environment", c_uint8),
+                ("quick_combat", c_uint8),
+        ]
+
+
+class StackObservationC(ctypes.Structure):
+        _fields_ = [
+                ("unit_type", c_uint16),
+                ("stack_size", c_uint16),
+                ("unit_health", c_uint16),
+                ("original_stack_size", c_uint16),
+                ("retaliations_remaining", c_int8),
+                ("x", c_int8),
+                ("y", c_int8),
+                ("is_attacker", c_uint8),
+                ("is_alive", c_uint8),
+                ("has_waited", c_uint8),
+                ("has_moved", c_uint8),
+                ("has_defended", c_uint8),
+                ("has_cast_spell", c_uint8),
+                ("has_moraled", c_uint8),
+                ("is_disabled", c_uint8),
+        ]
+
+
+class CombatObservationC(ctypes.Structure):
+        _fields_ = [
+                ("round", c_uint16),
+                ("attacker_moved_last", c_uint8),
+                ("is_siege", c_uint8),
+                ("is_quick_combat", c_uint8),
+                ("active_unit_id", c_int8),
+                ("active_unit_is_attacker", c_uint8),
+                ("active_unit_x", c_int8),
+                ("active_unit_y", c_int8),
+                ("attacker_mana", c_uint16),
+                ("defender_mana", c_uint16),
+                ("attacker_morale", c_int16),
+                ("defender_morale", c_int16),
+                ("attacker_luck", c_int16),
+                ("defender_luck", c_int16),
+                ("attacker_stack_count", c_uint8),
+                ("defender_stack_count", c_uint8),
+                ("attacker_stacks", StackObservationC * RL_COMBAT_MAX_ARMY_TROOPS),
+                ("defender_stacks", StackObservationC * RL_COMBAT_MAX_ARMY_TROOPS),
+        ]
+
+
+class CombatActionC(ctypes.Structure):
+        _fields_ = [
+                ("type", c_uint8),
+        ]
+
+
+def _default_library_candidates() -> Iterable[str]:
+        yield from (
+                os.environ.get("COF_CORE_LIB"),
+                "libcof_core.so",
+                "libcof_core.dylib",
+                "cof_core.dll",
+        )
+
+
+def ensure_library(path: Optional[str] = None) -> Library:
+        """Load the combat shared library, returning the cached handle."""
+
+        if not hasattr(ensure_library, "_cached"):
+                ensure_library._cached = None  # type: ignore[attr-defined]
+
+        lib = ensure_library._cached  # type: ignore[attr-defined]
+        if lib is not None:
+                return lib
+
+        candidates = []
+        if path:
+                candidates.append(path)
+        candidates.extend(filter(None, _default_library_candidates()))
+
+        last_error: Optional[Exception] = None
+        for candidate in candidates:
+                try:
+                        lib = ctypes.CDLL(candidate)
+                        ensure_library._cached = lib  # type: ignore[attr-defined]
+                        _configure_prototypes(lib)
+                        return lib
+                except OSError as exc:
+                        last_error = exc
+                        continue
+
+        raise RuntimeError(
+                "Unable to locate the Clash of Fantasy shared library; set COF_CORE_LIB"
+                " or provide an explicit path"
+        ) from last_error
+
+
+def _configure_prototypes(lib: Library) -> None:
+        lib.rl_combat_create_game.restype = GameHandle
+        lib.rl_combat_create_game.argtypes = []
+
+        lib.rl_combat_destroy_game.restype = None
+        lib.rl_combat_destroy_game.argtypes = [GameHandle]
+
+        lib.rl_combat_create_session.restype = SessionHandle
+        lib.rl_combat_create_session.argtypes = [GameHandle]
+
+        lib.rl_combat_destroy_session.restype = None
+        lib.rl_combat_destroy_session.argtypes = [SessionHandle]
+
+        lib.rl_combat_session_configure.restype = c_int
+        lib.rl_combat_session_configure.argtypes = [SessionHandle, POINTER(CombatScenarioC)]
+
+        lib.rl_combat_session_reset.restype = c_int
+        lib.rl_combat_session_reset.argtypes = [SessionHandle, POINTER(c_int)]
+
+        lib.rl_combat_session_step.restype = c_int
+        lib.rl_combat_session_step.argtypes = [SessionHandle, POINTER(c_int)]
+
+        lib.rl_combat_session_observation.restype = c_int
+        lib.rl_combat_session_observation.argtypes = [SessionHandle, POINTER(CombatObservationC)]
+
+        lib.rl_combat_session_apply_action.restype = c_int
+        lib.rl_combat_session_apply_action.argtypes = [SessionHandle, POINTER(CombatActionC)]
+
+        lib.rl_combat_session_battlefield.restype = BattlefieldPointer
+        lib.rl_combat_session_battlefield.argtypes = [SessionHandle]
+
+        lib.rl_combat_session_attacker.restype = c_void_p
+        lib.rl_combat_session_attacker.argtypes = [SessionHandle]
+
+        lib.rl_combat_session_defender.restype = c_void_p
+        lib.rl_combat_session_defender.argtypes = [SessionHandle]
+
+        lib.rl_combat_session_game.restype = c_void_p
+        lib.rl_combat_session_game.argtypes = [SessionHandle]

--- a/python/rl_combat/environment.py
+++ b/python/rl_combat/environment.py
@@ -1,0 +1,269 @@
+"""Reinforcement-learning environment scaffolding for Clash of Fantasy combat."""
+
+from __future__ import annotations
+
+import copy
+import random
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple, Union
+
+from .observation import EncodedCombatObservation, encode_combat_observation
+from .scenario import CombatScenario
+from .session import (BattleResult, CombatAction, CombatActionType,
+                      CombatSession)
+
+__all__ = [
+        "ControlledSide",
+        "EpisodeState",
+        "ScenarioGenerator",
+        "CombatEnvironment",
+]
+
+
+class ControlledSide(str, Enum):
+        """Indicate which combatant the agent controls."""
+
+        ATTACKER = "attacker"
+        DEFENDER = "defender"
+
+
+ScenarioGenerator = Union[
+        CombatScenario,
+        Callable[[random.Random], CombatScenario],
+        Callable[[random.Random, Optional[Mapping[str, Any]]], CombatScenario],
+]
+
+
+@dataclass
+class EpisodeState:
+        """Track metadata about the currently running episode."""
+
+        scenario: CombatScenario
+        seed: Optional[int]
+        steps: int = 0
+        result: BattleResult = BattleResult.IN_PROGRESS
+
+
+class CombatEnvironment:
+        """High-level environment wrapper that mirrors the Gymnasium API."""
+
+        def __init__(
+                self,
+                scenario: ScenarioGenerator,
+                *,
+                controlled_side: ControlledSide = ControlledSide.ATTACKER,
+                library_path: Optional[str] = None,
+        ) -> None:
+                self._scenario_factory = scenario
+                self._controlled_side = ControlledSide(controlled_side)
+                self._session = CombatSession(library_path)
+                self._rng = random.Random()
+                self._episode: Optional[EpisodeState] = None
+                self._last_action_invalid: bool = False
+
+        def close(self) -> None:
+                """Release native resources associated with the combat session."""
+
+                if self._session is not None:
+                        self._session.close()
+
+        def __enter__(self) -> "CombatEnvironment":
+                return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+                self.close()
+
+        @property
+        def session(self) -> CombatSession:
+                """Expose the underlying session for advanced integrations."""
+
+                return self._session
+
+        @property
+        def controlled_side(self) -> ControlledSide:
+                return self._controlled_side
+
+        def reset(
+                self,
+                *,
+                seed: Optional[int] = None,
+                options: Optional[Mapping[str, Any]] = None,
+        ) -> Tuple[EncodedCombatObservation, Dict[str, Any]]:
+                """Configure a new combat scenario and restart the battle."""
+
+                if seed is not None:
+                        self._rng.seed(seed)
+
+                scenario = self._resolve_scenario(options)
+                # Store a defensive copy to guard against mutation during training loops.
+                scenario_copy = copy.deepcopy(scenario)
+                self._apply_control_flags(scenario_copy)
+
+                self._session.configure(scenario_copy)
+                result = self._session.reset()
+
+                self._episode = EpisodeState(
+                        scenario=scenario_copy,
+                        seed=seed,
+                        steps=0,
+                        result=result,
+                )
+                self._last_action_invalid = False
+
+                observation = self._observe_controlled_state()
+                info = self._build_info(terminated=self._episode.result != BattleResult.IN_PROGRESS)
+                return observation, info
+
+        def step(
+                self,
+                action: Any,
+        ) -> Tuple[EncodedCombatObservation, float, bool, bool, Dict[str, Any]]:
+                """Advance the combat by a single agent decision."""
+
+                if self._episode is None:
+                        raise RuntimeError("Environment has not been reset")
+
+                if self._episode.result != BattleResult.IN_PROGRESS:
+                        raise RuntimeError("Episode already terminated; call reset() before step().")
+
+                self._apply_action(action)
+                result = self._session.step()
+
+                self._episode.steps += 1
+                self._episode.result = result
+
+                observation = self._observe_controlled_state()
+                reward = self._compute_reward(self._episode.result)
+                terminated = self._episode.result != BattleResult.IN_PROGRESS
+                info = self._build_info(terminated=terminated)
+
+                return observation, reward, terminated, False, info
+
+        def battlefield_pointer(self) -> int:
+                return self._session.battlefield_pointer()
+
+        def attacker_pointer(self) -> int:
+                return self._session.attacker_pointer()
+
+        def defender_pointer(self) -> int:
+                return self._session.defender_pointer()
+
+        def _resolve_scenario(self, options: Optional[Mapping[str, Any]]) -> CombatScenario:
+                if options and "scenario" in options:
+                        scenario = options["scenario"]
+                        if not isinstance(scenario, CombatScenario):
+                                raise TypeError("reset(options['scenario']) must be a CombatScenario instance")
+                        return scenario
+
+                factory = self._scenario_factory
+                if isinstance(factory, CombatScenario):
+                        return factory
+
+                if not callable(factory):
+                        raise TypeError("scenario must be a CombatScenario or callable")
+
+                try:
+                        return factory(self._rng, options)
+                except TypeError:
+                        return factory(self._rng)
+
+        def _encode_observation(self) -> EncodedCombatObservation:
+                observation = self._session.observation()
+                steps = self._episode.steps if self._episode is not None else 0
+                return encode_combat_observation(observation, steps=steps)
+
+        def _observe_controlled_state(self) -> EncodedCombatObservation:
+                """Advance the simulation until the controlled side is active and encode it."""
+
+                observation = self._session.observation()
+                while (
+                        self._episode is not None
+                        and self._episode.result == BattleResult.IN_PROGRESS
+                        and not self._is_controlled_turn(observation)
+                ):
+                        result = self._session.step()
+                        self._episode.result = result
+                        observation = self._session.observation()
+                        if result != BattleResult.IN_PROGRESS:
+                                break
+
+                steps = self._episode.steps if self._episode is not None else 0
+                return encode_combat_observation(observation, steps=steps)
+
+        def _apply_action(self, action: Any) -> None:
+                if action is None:
+                        resolved = CombatAction.auto_resolve()
+                elif isinstance(action, CombatAction):
+                        resolved = action
+                elif isinstance(action, CombatActionType):
+                        resolved = CombatAction(action)
+                elif isinstance(action, str):
+                        normalized = action.strip().lower()
+                        if normalized in {"wait"}:
+                                resolved = CombatAction.wait()
+                        elif normalized in {"defend"}:
+                                resolved = CombatAction.defend()
+                        elif normalized in {"auto", "auto_resolve", "auto-resolve"}:
+                                resolved = CombatAction.auto_resolve()
+                        else:
+                                raise ValueError(f"Unsupported action string: {action}")
+                else:
+                        raise TypeError("Action must be a CombatAction, CombatActionType, string, or None")
+
+                success = self._session.apply_action(resolved)
+                self._last_action_invalid = not success
+                if not success:
+                        if resolved.action_type is CombatActionType.AUTO_RESOLVE:
+                                raise RuntimeError("Auto-resolve action was rejected by the engine")
+                        self._session.apply_action(CombatAction.auto_resolve())
+
+        def _apply_control_flags(self, scenario: CombatScenario) -> None:
+                """Mark the non-controlled hero as AI-driven for the upcoming episode."""
+
+                controls_attacker = self._controlled_side is ControlledSide.ATTACKER
+                scenario.attacker.human_controlled = controls_attacker
+                scenario.defender.human_controlled = not controls_attacker
+
+        def _is_controlled_turn(self, observation: Any) -> bool:
+                active_side = getattr(observation, "active_unit_is_attacker", None)
+                if active_side is None:
+                        return True
+                if self._controlled_side is ControlledSide.ATTACKER:
+                        return bool(active_side)
+                return not bool(active_side)
+
+        def _compute_reward(self, result: BattleResult) -> float:
+                if result == BattleResult.IN_PROGRESS:
+                        return 0.0
+
+                if result == BattleResult.BOTH_LOSE:
+                        return -1.0
+
+                if result in (BattleResult.ATTACKER_HAS_FLED, BattleResult.ATTACKER_VICTORY):
+                        return 1.0 if self._controlled_side is ControlledSide.ATTACKER else -1.0
+
+                if result in (BattleResult.DEFENDER_HAS_FLED, BattleResult.DEFENDER_VICTORY):
+                        return 1.0 if self._controlled_side is ControlledSide.DEFENDER else -1.0
+
+                return 0.0
+
+        def _build_info(self, *, terminated: bool) -> Dict[str, Any]:
+                assert self._episode is not None
+
+                info: Dict[str, Any] = {
+                        "battle_result": self._episode.result,
+                        "controlled_side": self._controlled_side,
+                        "steps": self._episode.steps,
+                        "terminated": terminated,
+                }
+
+                if self._episode.seed is not None:
+                        info["seed"] = self._episode.seed
+
+                info["battlefield_ptr"] = self.battlefield_pointer()
+                info["attacker_ptr"] = self.attacker_pointer()
+                info["defender_ptr"] = self.defender_pointer()
+                info["invalid_action"] = self._last_action_invalid
+
+                return info

--- a/python/rl_combat/observation.py
+++ b/python/rl_combat/observation.py
@@ -1,0 +1,143 @@
+"""Observation encoding helpers for the combat reinforcement-learning stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import chain
+from typing import Iterable, Sequence, Tuple
+
+from . import bindings
+from .session import CombatObservation, StackObservation
+
+__all__ = [
+    "EncodedCombatObservation",
+    "encode_combat_observation",
+    "flatten_observation",
+    "STACK_FEATURE_COUNT",
+    "GLOBAL_FEATURE_COUNT",
+]
+
+STACK_FEATURE_COUNT = 16
+GLOBAL_FEATURE_COUNT = 16
+
+
+def _bool(value: bool) -> float:
+    return 1.0 if bool(value) else 0.0
+
+
+@dataclass(frozen=True)
+class EncodedCombatObservation:
+    """Structured representation of encoded combat features."""
+
+    raw: CombatObservation
+    steps: int
+    global_features: Tuple[float, ...]
+    attacker_stack_features: Tuple[Tuple[float, ...], ...]
+    defender_stack_features: Tuple[Tuple[float, ...], ...]
+
+    @property
+    def vector(self) -> Tuple[float, ...]:
+        """Return the flattened observation vector."""
+
+        return tuple(
+            chain(
+                self.global_features,
+                chain.from_iterable(self.attacker_stack_features),
+                chain.from_iterable(self.defender_stack_features),
+            )
+        )
+
+
+def flatten_observation(observation: EncodedCombatObservation) -> Tuple[float, ...]:
+    """Convenience wrapper returning the flattened observation vector."""
+
+    return observation.vector
+
+
+def encode_combat_observation(
+    observation: CombatObservation,
+    *,
+    steps: int = 0,
+) -> EncodedCombatObservation:
+    """Encode a raw combat observation into fixed-size feature tuples."""
+
+    global_features = _encode_global_features(observation, steps)
+    attacker_features = _encode_stack_block(observation.attacker_stacks)
+    defender_features = _encode_stack_block(observation.defender_stacks)
+
+    return EncodedCombatObservation(
+        raw=observation,
+        steps=steps,
+        global_features=global_features,
+        attacker_stack_features=attacker_features,
+        defender_stack_features=defender_features,
+    )
+
+
+def _encode_global_features(
+    observation: CombatObservation, steps: int
+) -> Tuple[float, ...]:
+    active_exists = observation.active_unit_id >= 0
+    active_x, active_y = observation.active_unit_position
+    if not active_exists:
+        active_x = -1
+        active_y = -1
+    active_is_attacker = (
+        _bool(observation.active_unit_is_attacker)
+        if observation.active_unit_is_attacker is not None
+        else 0.0
+    )
+
+    features: Sequence[float] = (
+        float(observation.round),
+        float(steps),
+        _bool(observation.attacker_moved_last),
+        _bool(observation.is_siege),
+        _bool(observation.is_quick_combat),
+        float(observation.active_unit_id),
+        _bool(active_exists),
+        active_is_attacker,
+        float(active_x),
+        float(active_y),
+        float(observation.attacker_mana),
+        float(observation.defender_mana),
+        float(observation.attacker_morale),
+        float(observation.defender_morale),
+        float(observation.attacker_luck),
+        float(observation.defender_luck),
+    )
+    return tuple(features)
+
+
+def _encode_stack_block(
+    stacks: Iterable[StackObservation],
+) -> Tuple[Tuple[float, ...], ...]:
+    rows = [[0.0] * STACK_FEATURE_COUNT for _ in range(bindings.RL_COMBAT_MAX_ARMY_TROOPS)]
+
+    for index, stack in enumerate(stacks):
+        if index >= bindings.RL_COMBAT_MAX_ARMY_TROOPS:
+            break
+        rows[index] = list(_encode_stack(stack))
+
+    return tuple(tuple(row) for row in rows)
+
+
+def _encode_stack(stack: StackObservation) -> Tuple[float, ...]:
+    return (
+        1.0,
+        float(stack.unit_type),
+        float(stack.stack_size),
+        float(stack.unit_health),
+        float(stack.original_stack_size),
+        float(stack.retaliations_remaining),
+        float(stack.position[0]),
+        float(stack.position[1]),
+        _bool(stack.is_attacker),
+        _bool(stack.is_alive),
+        _bool(stack.has_waited),
+        _bool(stack.has_moved),
+        _bool(stack.has_defended),
+        _bool(stack.has_cast_spell),
+        _bool(stack.has_moraled),
+        _bool(stack.is_disabled),
+    )

--- a/python/rl_combat/scenario.py
+++ b/python/rl_combat/scenario.py
@@ -1,0 +1,140 @@
+"""High-level data structures for configuring combat scenarios via Python."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass, field
+from typing import List, Sequence, Tuple
+
+from . import bindings
+
+__all__ = ["CombatScenario", "HeroLoadout", "TroopStack"]
+
+
+@dataclass(frozen=True)
+class TroopStack:
+        """Describe a single troop stack to assign to a hero."""
+
+        unit_type: int
+        stack_size: int
+
+        def to_c(self) -> bindings.TroopStackC:
+                stack = bindings.TroopStackC()
+                stack.unit_type = int(self.unit_type)
+                stack.stack_size = int(self.stack_size)
+                return stack
+
+
+@dataclass
+class HeroLoadout:
+        """Specification of a hero loadout for a combat scenario."""
+
+        player: int = 1
+        hero_class: int = 0
+        hero_id: int = 0
+        name: str = ""
+        level: int = 1
+        experience: int = 0
+        attack: int = 0
+        defense: int = 0
+        power: int = 1
+        knowledge: int = 1
+        mana: int = 10
+        dark_energy: int = 0
+        has_ballista: bool = False
+        human_controlled: bool = True
+        troops: Sequence[TroopStack] = field(default_factory=tuple)
+        talents: Sequence[int] = field(default_factory=tuple)
+        spells: Sequence[int] = field(default_factory=tuple)
+        skills: Sequence[int] = field(default_factory=tuple)
+
+        def to_c_struct(self) -> Tuple[bindings.HeroLoadoutC, List[object]]:
+                loadout = bindings.HeroLoadoutC()
+                loadout.player = int(self.player) & 0xFF
+                loadout.hero_class = int(self.hero_class) & 0xFF
+                loadout.hero_id = int(self.hero_id) & 0xFFFF
+                name_bytes = self.name.encode("utf-8") if self.name else None
+                loadout.name = name_bytes
+                loadout.level = int(self.level) & 0xFF
+                loadout.experience = int(self.experience) & 0xFFFFFFFFFFFFFFFF
+                loadout.attack = int(self.attack) & 0xFF
+                loadout.defense = int(self.defense) & 0xFF
+                loadout.power = int(self.power) & 0xFF
+                loadout.knowledge = int(self.knowledge) & 0xFF
+                loadout.mana = int(self.mana) & 0xFFFF
+                loadout.dark_energy = int(self.dark_energy) & 0xFFFF
+                loadout.has_ballista = 1 if self.has_ballista else 0
+                loadout.human_controlled = 1 if self.human_controlled else 0
+
+                buffers: List[object] = []
+                if name_bytes:
+                        buffers.append(name_bytes)
+
+                if self.troops:
+                        troop_array_type = bindings.TroopStackC * len(self.troops)
+                        troop_array = troop_array_type(*[troop.to_c() for troop in self.troops])
+                        loadout.troops = ctypes.cast(troop_array, ctypes.POINTER(bindings.TroopStackC))
+                        loadout.troop_count = len(self.troops)
+                        buffers.append(troop_array)
+                else:
+                        loadout.troops = ctypes.POINTER(bindings.TroopStackC)()
+                        loadout.troop_count = 0
+
+                if self.talents:
+                        talent_array_type = ctypes.c_uint8 * len(self.talents)
+                        talent_array = talent_array_type(*[int(t) & 0xFF for t in self.talents])
+                        loadout.talents = ctypes.cast(talent_array, ctypes.POINTER(ctypes.c_uint8))
+                        loadout.talent_count = len(self.talents)
+                        buffers.append(talent_array)
+                else:
+                        loadout.talents = ctypes.POINTER(ctypes.c_uint8)()
+                        loadout.talent_count = 0
+
+                if self.spells:
+                        spell_array_type = ctypes.c_uint16 * len(self.spells)
+                        spell_array = spell_array_type(*[int(s) & 0xFFFF for s in self.spells])
+                        loadout.spells = ctypes.cast(spell_array, ctypes.POINTER(ctypes.c_uint16))
+                        loadout.spell_count = len(self.spells)
+                        buffers.append(spell_array)
+                else:
+                        loadout.spells = ctypes.POINTER(ctypes.c_uint16)()
+                        loadout.spell_count = 0
+
+                if self.skills:
+                        skill_array_type = ctypes.c_uint8 * len(self.skills)
+                        skill_array = skill_array_type(*[int(s) & 0xFF for s in self.skills])
+                        loadout.skills = ctypes.cast(skill_array, ctypes.POINTER(ctypes.c_uint8))
+                        loadout.skill_count = len(self.skills)
+                        buffers.append(skill_array)
+                else:
+                        loadout.skills = ctypes.POINTER(ctypes.c_uint8)()
+                        loadout.skill_count = 0
+
+                return loadout, buffers
+
+
+@dataclass
+class CombatScenario:
+        """Aggregate attacker/defender hero specifications for combat."""
+
+        attacker: HeroLoadout
+        defender: HeroLoadout
+        is_deathmatch: bool = False
+        environment: int = 0
+        quick_combat: bool = False
+
+        def to_c_struct(self) -> Tuple[bindings.CombatScenarioC, List[object]]:
+                attacker_c, attacker_buffers = self.attacker.to_c_struct()
+                defender_c, defender_buffers = self.defender.to_c_struct()
+
+                scenario_c = bindings.CombatScenarioC()
+                scenario_c.attacker = attacker_c
+                scenario_c.defender = defender_c
+                scenario_c.is_deathmatch = 1 if self.is_deathmatch else 0
+                scenario_c.environment = int(self.environment) & 0xFF
+                scenario_c.quick_combat = 1 if self.quick_combat else 0
+
+                buffers: List[object] = []
+                buffers.extend(attacker_buffers)
+                buffers.extend(defender_buffers)
+                return scenario_c, buffers

--- a/python/rl_combat/session.py
+++ b/python/rl_combat/session.py
@@ -1,0 +1,320 @@
+"""High-level session wrapper for driving combat simulations from Python."""
+
+from __future__ import annotations
+
+import ctypes
+from ctypes import c_int, c_uint8
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import bindings
+from .scenario import CombatScenario
+
+__all__ = [
+        "BattleResult",
+        "CombatAction",
+        "CombatActionType",
+        "CombatObservation",
+        "CombatSession",
+        "StackObservation",
+]
+
+
+class BattleResult(IntEnum):
+        """Mirror the `battle_result_e` enum from the engine."""
+
+        IN_PROGRESS = 0
+        ATTACKER_VICTORY = 1
+        DEFENDER_VICTORY = 2
+        ATTACKER_HAS_FLED = 3
+        DEFENDER_HAS_FLED = 4
+        BOTH_LOSE = 5
+
+
+class CombatActionType(IntEnum):
+        """Enumerate the high-level combat commands exposed through the C API."""
+
+        WAIT = 0
+        DEFEND = 1
+        AUTO_RESOLVE = 2
+
+
+@dataclass(frozen=True)
+class CombatAction:
+        """Wrap a combat command issued by the agent."""
+
+        action_type: CombatActionType
+
+        @classmethod
+        def wait(cls) -> "CombatAction":
+                return cls(CombatActionType.WAIT)
+
+        @classmethod
+        def defend(cls) -> "CombatAction":
+                return cls(CombatActionType.DEFEND)
+
+        @classmethod
+        def auto_resolve(cls) -> "CombatAction":
+                return cls(CombatActionType.AUTO_RESOLVE)
+
+
+@dataclass
+class StackObservation:
+        """Lightweight representation of a battlefield unit stack."""
+
+        unit_type: int
+        stack_size: int
+        unit_health: int
+        original_stack_size: int
+        retaliations_remaining: int
+        position: Tuple[int, int]
+        is_attacker: bool
+        is_alive: bool
+        has_waited: bool
+        has_moved: bool
+        has_defended: bool
+        has_cast_spell: bool
+        has_moraled: bool
+        is_disabled: bool
+
+        @staticmethod
+        def from_c_struct(data: bindings.StackObservationC) -> "StackObservation":
+                return StackObservation(
+                        unit_type=int(data.unit_type),
+                        stack_size=int(data.stack_size),
+                        unit_health=int(data.unit_health),
+                        original_stack_size=int(data.original_stack_size),
+                        retaliations_remaining=int(data.retaliations_remaining),
+                        position=(int(data.x), int(data.y)),
+                        is_attacker=bool(data.is_attacker),
+                        is_alive=bool(data.is_alive),
+                        has_waited=bool(data.has_waited),
+                        has_moved=bool(data.has_moved),
+                        has_defended=bool(data.has_defended),
+                        has_cast_spell=bool(data.has_cast_spell),
+                        has_moraled=bool(data.has_moraled),
+                        is_disabled=bool(data.is_disabled),
+                )
+
+        def to_dict(self) -> Dict[str, Any]:
+                return {
+                        "unit_type": self.unit_type,
+                        "stack_size": self.stack_size,
+                        "unit_health": self.unit_health,
+                        "original_stack_size": self.original_stack_size,
+                        "retaliations_remaining": self.retaliations_remaining,
+                        "position": self.position,
+                        "is_attacker": self.is_attacker,
+                        "is_alive": self.is_alive,
+                        "has_waited": self.has_waited,
+                        "has_moved": self.has_moved,
+                        "has_defended": self.has_defended,
+                        "has_cast_spell": self.has_cast_spell,
+                        "has_moraled": self.has_moraled,
+                        "is_disabled": self.is_disabled,
+                }
+
+
+@dataclass
+class CombatObservation:
+        """Snapshot of the current battle state suitable for policy consumption."""
+
+        round: int
+        attacker_moved_last: bool
+        is_siege: bool
+        is_quick_combat: bool
+        active_unit_id: int
+        active_unit_is_attacker: Optional[bool]
+        active_unit_position: Tuple[int, int]
+        attacker_mana: int
+        defender_mana: int
+        attacker_morale: int
+        defender_morale: int
+        attacker_luck: int
+        defender_luck: int
+        attacker_stacks: List[StackObservation]
+        defender_stacks: List[StackObservation]
+
+        @staticmethod
+        def from_c_struct(data: bindings.CombatObservationC) -> "CombatObservation":
+                attacker_stacks = [
+                        StackObservation.from_c_struct(data.attacker_stacks[i])
+                        for i in range(int(data.attacker_stack_count))
+                ]
+                defender_stacks = [
+                        StackObservation.from_c_struct(data.defender_stacks[i])
+                        for i in range(int(data.defender_stack_count))
+                ]
+                active_id = int(data.active_unit_id)
+                active_is_attacker: Optional[bool]
+                if active_id < 0:
+                        active_is_attacker = None
+                else:
+                        active_is_attacker = bool(data.active_unit_is_attacker)
+
+                return CombatObservation(
+                        round=int(data.round),
+                        attacker_moved_last=bool(data.attacker_moved_last),
+                        is_siege=bool(data.is_siege),
+                        is_quick_combat=bool(data.is_quick_combat),
+                        active_unit_id=active_id,
+                        active_unit_is_attacker=active_is_attacker,
+                        active_unit_position=(int(data.active_unit_x), int(data.active_unit_y)),
+                        attacker_mana=int(data.attacker_mana),
+                        defender_mana=int(data.defender_mana),
+                        attacker_morale=int(data.attacker_morale),
+                        defender_morale=int(data.defender_morale),
+                        attacker_luck=int(data.attacker_luck),
+                        defender_luck=int(data.defender_luck),
+                        attacker_stacks=attacker_stacks,
+                        defender_stacks=defender_stacks,
+                )
+
+        def to_dict(self) -> Dict[str, Any]:
+                return {
+                        "round": self.round,
+                        "attacker_moved_last": self.attacker_moved_last,
+                        "is_siege": self.is_siege,
+                        "is_quick_combat": self.is_quick_combat,
+                        "active_unit_id": self.active_unit_id,
+                        "active_unit_is_attacker": self.active_unit_is_attacker,
+                        "active_unit_position": self.active_unit_position,
+                        "attacker_mana": self.attacker_mana,
+                        "defender_mana": self.defender_mana,
+                        "attacker_morale": self.attacker_morale,
+                        "defender_morale": self.defender_morale,
+                        "attacker_luck": self.attacker_luck,
+                        "defender_luck": self.defender_luck,
+                        "attacker_stacks": [stack.to_dict() for stack in self.attacker_stacks],
+                        "defender_stacks": [stack.to_dict() for stack in self.defender_stacks],
+                }
+
+
+class CombatSession:
+        """Manage the lifecycle of a combat session via the shared library."""
+
+        def __init__(self, library_path: Optional[str] = None) -> None:
+                self._lib = bindings.ensure_library(library_path)
+                self._game = self._lib.rl_combat_create_game()
+                if not self._game:
+                        raise RuntimeError("Failed to allocate combat game handle")
+
+                self._session = self._lib.rl_combat_create_session(self._game)
+                if not self._session:
+                        self._lib.rl_combat_destroy_game(self._game)
+                        raise RuntimeError("Failed to allocate combat session handle")
+
+                self._closed = False
+
+        def __enter__(self) -> "CombatSession":
+                return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+                self.close()
+
+        def __del__(self) -> None:
+                try:
+                        self.close()
+                except Exception:
+                        pass
+
+        def close(self) -> None:
+                if self._closed:
+                        return
+
+                if getattr(self, "_session", None):
+                        self._lib.rl_combat_destroy_session(self._session)
+                        self._session = None
+
+                if getattr(self, "_game", None):
+                        self._lib.rl_combat_destroy_game(self._game)
+                        self._game = None
+
+                self._closed = True
+
+        @property
+        def closed(self) -> bool:
+                return self._closed
+
+        def configure(self, scenario: CombatScenario) -> None:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+
+                scenario_c, buffers = scenario.to_c_struct()
+                try:
+                        result = self._lib.rl_combat_session_configure(self._session, ctypes.byref(scenario_c))
+                finally:
+                        buffers.clear()
+
+                if result != 0:
+                        raise RuntimeError(f"Failed to configure combat session (error {result})")
+
+        def reset(self) -> BattleResult:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+
+                result_value = c_int(0)
+                error = self._lib.rl_combat_session_reset(self._session, ctypes.byref(result_value))
+                if error != 0:
+                        raise RuntimeError(f"Combat reset failed (error {error})")
+
+                return BattleResult(result_value.value)
+
+        def step(self) -> BattleResult:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+
+                result_value = c_int(0)
+                error = self._lib.rl_combat_session_step(self._session, ctypes.byref(result_value))
+                if error != 0:
+                        raise RuntimeError(f"Combat step failed (error {error})")
+
+                return BattleResult(result_value.value)
+
+        def observation(self) -> CombatObservation:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+
+                observation_c = bindings.CombatObservationC()
+                error = self._lib.rl_combat_session_observation(self._session, ctypes.byref(observation_c))
+                if error != 0:
+                        raise RuntimeError(f"Failed to extract combat observation (error {error})")
+
+                return CombatObservation.from_c_struct(observation_c)
+
+        def apply_action(self, action: "CombatAction") -> bool:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+
+                if not isinstance(action, CombatAction):
+                        raise TypeError("action must be a CombatAction instance")
+
+                action_c = bindings.CombatActionC()
+                action_c.type = c_uint8(action.action_type.value)
+                error = self._lib.rl_combat_session_apply_action(self._session, ctypes.byref(action_c))
+                if error == 0:
+                        return True
+                if error == -3:
+                        return False
+                raise RuntimeError(f"Combat action failed (error {error})")
+
+        def battlefield_pointer(self) -> int:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+                return int(self._lib.rl_combat_session_battlefield(self._session))
+
+        def attacker_pointer(self) -> int:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+                return int(self._lib.rl_combat_session_attacker(self._session))
+
+        def defender_pointer(self) -> int:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+                return int(self._lib.rl_combat_session_defender(self._session))
+
+        def game_pointer(self) -> int:
+                if self._closed:
+                        raise RuntimeError("CombatSession has already been closed")
+                return int(self._lib.rl_combat_session_game(self._session))

--- a/python/rl_combat/training/__init__.py
+++ b/python/rl_combat/training/__init__.py
@@ -1,0 +1,34 @@
+"""Training scaffolding for reinforcement-learning agents."""
+
+from .config import DQNConfig, SelfPlayConfig
+from .dqn import DQNTrainer, DiscreteActionSpace, EpsilonSchedule, TrainingMetrics
+from .encoders import (
+    batch_observations_to_tensor,
+    encoded_observation_size,
+    encoded_observation_to_tensor,
+)
+from .networks import CombatMLP, build_mlp_q_network, combat_observation_dim
+from .policies import BasePolicy, RandomPolicy
+from .replay_buffer import ReplayBuffer, Transition
+from .self_play import EpisodeRecord, SelfPlayRunner
+
+__all__ = [
+    "BasePolicy",
+    "CombatMLP",
+    "DQNConfig",
+    "DQNTrainer",
+    "DiscreteActionSpace",
+    "EpsilonSchedule",
+    "EpisodeRecord",
+    "RandomPolicy",
+    "ReplayBuffer",
+    "SelfPlayConfig",
+    "SelfPlayRunner",
+    "TrainingMetrics",
+    "Transition",
+    "batch_observations_to_tensor",
+    "build_mlp_q_network",
+    "combat_observation_dim",
+    "encoded_observation_size",
+    "encoded_observation_to_tensor",
+]

--- a/python/rl_combat/training/config.py
+++ b/python/rl_combat/training/config.py
@@ -1,0 +1,35 @@
+"""Configuration dataclasses for reinforcement-learning training loops."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class DQNConfig:
+    """Hyperparameters controlling Deep Q-Network optimisation."""
+
+    discount: float = 0.99
+    batch_size: int = 64
+    minimum_buffer_size: int = 1_000
+    training_frequency: int = 1
+    target_update_frequency: int = 1_000
+    evaluation_interval: Optional[int] = 10_000
+    gradient_clip_norm: Optional[float] = 5.0
+    max_steps_per_episode: Optional[int] = None
+    replay_buffer_capacity: int = 200_000
+    logging_interval: int = 1_000
+
+
+@dataclass
+class SelfPlayConfig:
+    """Parameters governing how self-play episodes are generated."""
+
+    episodes_per_cycle: int = 1
+    attacker_advantage: float = 0.0
+    defender_advantage: float = 0.0
+    scenario_options: Dict[str, Any] = field(default_factory=dict)
+    alternate_controlled_side: bool = True
+    random_seed: Optional[int] = None
+    max_steps_per_episode: Optional[int] = None

--- a/python/rl_combat/training/dqn.py
+++ b/python/rl_combat/training/dqn.py
@@ -1,0 +1,378 @@
+"""Deep Q-Network training scaffolding for Clash of Fantasy combat."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
+
+from ..environment import CombatEnvironment, ControlledSide
+from ..session import CombatAction
+from .config import DQNConfig
+from .replay_buffer import ReplayBuffer, Transition
+
+try:  # Optional at import time; actual training will require torch installed.
+    import torch
+    from torch import Tensor
+    from torch.nn import Module
+    from torch.optim import Optimizer
+except ImportError:  # pragma: no cover - torch is optional for static analysis
+    torch = None  # type: ignore
+    Tensor = Any  # type: ignore
+    Module = Any  # type: ignore
+    Optimizer = Any  # type: ignore
+
+ObservationEncoder = Callable[[Any], "Tensor"]
+LegalActionFunction = Callable[[Any], Optional[Union[Sequence[int], Sequence[bool], "Tensor"]]]
+
+
+@dataclass
+class DiscreteActionSpace:
+    """Map integer action indices to native combat commands."""
+
+    actions: Sequence[CombatAction]
+
+    def __post_init__(self) -> None:
+        if not self.actions:
+            raise ValueError("actions must contain at least one CombatAction")
+
+    @property
+    def size(self) -> int:
+        return len(self.actions)
+
+    def to_native(self, index: int) -> CombatAction:
+        if index < 0 or index >= len(self.actions):
+            raise IndexError(f"Action index {index} out of range")
+        return self.actions[index]
+
+
+@dataclass
+class TrainingMetrics:
+    """Aggregated statistics captured during training."""
+
+    episode_rewards: List[float] = field(default_factory=list)
+    losses: List[float] = field(default_factory=list)
+    epsilon_values: List[float] = field(default_factory=list)
+    total_steps: int = 0
+
+    def record_episode(self, reward: float, epsilon: float) -> None:
+        self.episode_rewards.append(reward)
+        self.epsilon_values.append(epsilon)
+
+    def record_losses(self, values: Iterable[float]) -> None:
+        self.losses.extend(values)
+
+
+@dataclass
+class EpsilonSchedule:
+    """Linearly anneal epsilon-greedy exploration over time."""
+
+    start: float = 1.0
+    end: float = 0.05
+    decay_steps: int = 100_000
+
+    def value(self, step: int) -> float:
+        if step >= self.decay_steps:
+            return self.end
+        fraction = step / max(1, self.decay_steps)
+        return self.start + fraction * (self.end - self.start)
+
+
+class DQNTrainer:
+    """Coordinate data collection and optimisation for a DQN agent."""
+
+    def __init__(
+        self,
+        policy_network: "Module",
+        target_network: "Module",
+        optimizer: "Optimizer",
+        replay_buffer: ReplayBuffer,
+        env_factory: Callable[[ControlledSide], CombatEnvironment],
+        observation_encoder: ObservationEncoder,
+        action_space: DiscreteActionSpace,
+        *,
+        legal_action_fn: Optional[LegalActionFunction] = None,
+        config: Optional[DQNConfig] = None,
+        epsilon_schedule: Optional[EpsilonSchedule] = None,
+        policy_side: ControlledSide = ControlledSide.ATTACKER,
+        device: Optional[str] = None,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        if torch is None:
+            raise RuntimeError("torch is required to instantiate DQNTrainer")
+
+        self._policy_net = policy_network
+        self._target_net = target_network
+        self._optimizer = optimizer
+        self._replay_buffer = replay_buffer
+        self._env_factory = env_factory
+        self._encoder = observation_encoder
+        self._action_space = action_space
+        self._legal_action_fn = legal_action_fn
+        self._config = config or DQNConfig()
+        self._epsilon_schedule = epsilon_schedule or EpsilonSchedule()
+        self._side = policy_side
+        self._device = torch.device(device) if device else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._rng = rng or random.Random()
+
+        self._policy_net.to(self._device)
+        self._target_net.to(self._device)
+        self._target_net.load_state_dict(self._policy_net.state_dict())
+        self._target_net.eval()
+
+        self._global_step = 0
+
+    def train(self, episodes: int) -> TrainingMetrics:
+        metrics = TrainingMetrics()
+
+        for _ in range(episodes):
+            reward, epsilon, losses = self._run_episode()
+            metrics.record_episode(reward, epsilon)
+            metrics.record_losses(losses)
+            metrics.total_steps = self._global_step
+
+        return metrics
+
+    def _run_episode(self) -> Tuple[float, float, List[float]]:
+        epsilon = self._epsilon_schedule.value(self._global_step)
+        cumulative_reward = 0.0
+        episode_losses: List[float] = []
+
+        env = self._env_factory(self._side)
+        with env:
+            observation, info = env.reset()
+            state_tensor = self._ensure_tensor(self._encoder(observation))
+
+            terminated = bool(info.get("terminated", False))
+            steps = 0
+            max_steps = self._config.max_steps_per_episode
+
+            while not terminated:
+                legal_mask = self._compute_legal_mask(observation)
+                action_index = self._select_action(state_tensor, epsilon, legal_mask)
+                action = self._action_space.to_native(action_index)
+
+                next_observation, reward, terminated, truncated, _ = env.step(action)
+                done = bool(terminated or truncated)
+                next_state_tensor = self._ensure_tensor(self._encoder(next_observation))
+                next_legal_mask = self._compute_legal_mask(next_observation)
+
+                transition = Transition(
+                    state=state_tensor.detach().cpu(),
+                    action=action_index,
+                    reward=float(reward),
+                    next_state=next_state_tensor.detach().cpu(),
+                    done=done,
+                    legal_actions_mask=legal_mask,
+                    next_legal_actions_mask=next_legal_mask,
+                )
+                self._replay_buffer.append(transition)
+
+                state_tensor = next_state_tensor
+                observation = next_observation
+                cumulative_reward += float(reward)
+                steps += 1
+                self._global_step += 1
+
+                if (
+                    self._replay_buffer.ready_for_training(self._config.minimum_buffer_size)
+                    and self._global_step % self._config.training_frequency == 0
+                ):
+                    loss = self._optimise_model()
+                    if loss is not None:
+                        episode_losses.append(loss)
+
+                if self._global_step % self._config.target_update_frequency == 0:
+                    self._target_net.load_state_dict(self._policy_net.state_dict())
+
+                if max_steps is not None and steps >= max_steps:
+                    break
+
+                if truncated:
+                    break
+
+        return cumulative_reward, epsilon, episode_losses
+
+    def _optimise_model(self) -> Optional[float]:
+        if torch is None:
+            return None
+        batch_size = self._config.batch_size
+        if len(self._replay_buffer) < batch_size:
+            return None
+
+        transitions = self._replay_buffer.sample(batch_size)
+        states = torch.stack([self._ensure_tensor(t.state) for t in transitions])
+        actions = torch.tensor([t.action for t in transitions], dtype=torch.long, device=self._device)
+        rewards = torch.tensor([t.reward for t in transitions], dtype=torch.float32, device=self._device)
+        next_states = torch.stack([self._ensure_tensor(t.next_state) for t in transitions])
+        dones = torch.tensor([t.done for t in transitions], dtype=torch.float32, device=self._device)
+
+        q_values = self._policy_net(states)
+        action_q = q_values.gather(1, actions.unsqueeze(1)).squeeze(1)
+
+        with torch.no_grad():
+            next_q_values = self._target_net(next_states)
+            next_q_values = self._apply_legal_mask_batch(next_q_values, [t.next_legal_actions_mask for t in transitions])
+            max_next_q, _ = next_q_values.max(dim=1)
+            targets = rewards + self._config.discount * (1.0 - dones) * max_next_q
+
+        criterion = torch.nn.MSELoss()
+        loss_tensor = criterion(action_q, targets)
+
+        self._optimizer.zero_grad()
+        loss_tensor.backward()
+
+        if self._config.gradient_clip_norm is not None:
+            torch.nn.utils.clip_grad_norm_(self._policy_net.parameters(), self._config.gradient_clip_norm)
+
+        self._optimizer.step()
+
+        return float(loss_tensor.item())
+
+    def _select_action(
+        self,
+        state: "Tensor",
+        epsilon: float,
+        legal_mask: Optional[Union[Sequence[int], Sequence[bool], "Tensor"]],
+    ) -> int:
+        if torch is None:
+            raise RuntimeError("torch is required for action selection")
+
+        if self._rng.random() < epsilon:
+            return self._sample_random_action(legal_mask)
+
+        self._policy_net.eval()
+        with torch.no_grad():
+            q_values = self._policy_net(state.unsqueeze(0).to(self._device)).squeeze(0)
+            q_values = self._apply_legal_mask(q_values, legal_mask)
+            action = int(torch.argmax(q_values).item())
+        self._policy_net.train()
+        return action
+
+    def _sample_random_action(
+        self,
+        legal_mask: Optional[Union[Sequence[int], Sequence[bool], "Tensor"]],
+    ) -> int:
+        available = self._resolve_legal_indices(legal_mask)
+        if not available:
+            available = list(range(self._action_space.size))
+        return self._rng.choice(available)
+
+    def _compute_legal_mask(self, observation: Any) -> Optional[Union[Sequence[int], Sequence[bool], "Tensor"]]:
+        if self._legal_action_fn is None:
+            return None
+        return self._legal_action_fn(observation)
+
+    def _resolve_legal_indices(
+        self,
+        legal_mask: Optional[Union[Sequence[int], Sequence[bool], "Tensor"]],
+    ) -> List[int]:
+        if legal_mask is None:
+            return list(range(self._action_space.size))
+
+        if torch is not None and isinstance(legal_mask, torch.Tensor):
+            mask_tensor = legal_mask.detach().cpu()
+            if mask_tensor.dtype == torch.bool:
+                indices = [i for i, allowed in enumerate(mask_tensor.tolist()) if allowed]
+            else:
+                values = mask_tensor.tolist()
+                indices = [i for i, allowed in enumerate(values) if allowed > 0]
+            return indices
+
+        if isinstance(legal_mask, Sequence) and legal_mask:
+            first = legal_mask[0]
+            if isinstance(first, bool):
+                return [i for i, allowed in enumerate(legal_mask) if allowed]
+            if isinstance(first, int):
+                return [int(idx) for idx in legal_mask]
+            if isinstance(first, float):
+                return [i for i, allowed in enumerate(legal_mask) if allowed > 0]
+
+        # Fallback that treats the iterable as explicit indices
+        try:
+            return [int(idx) for idx in legal_mask]  # type: ignore[arg-type]
+        except TypeError:
+            return list(range(self._action_space.size))
+
+    def _apply_legal_mask(
+        self,
+        q_values: "Tensor",
+        legal_mask: Optional[Union[Sequence[int], Sequence[bool], "Tensor"]],
+    ) -> "Tensor":
+        if legal_mask is None:
+            return q_values
+
+        mask = self._to_mask_tensor(legal_mask, q_values.shape[-1])
+        return q_values.masked_fill(~mask, float("-inf"))
+
+    def _apply_legal_mask_batch(
+        self,
+        q_values: "Tensor",
+        masks: Iterable[Optional[Union[Sequence[int], Sequence[bool], "Tensor"]]],
+    ) -> "Tensor":
+        if all(mask is None for mask in masks):
+            return q_values
+
+        mask_tensors = [self._to_mask_tensor(mask, q_values.shape[-1]) if mask is not None else None for mask in masks]
+        stacked_masks = torch.stack([
+            mask if mask is not None else torch.ones(q_values.shape[-1], dtype=torch.bool, device=q_values.device)
+            for mask in mask_tensors
+        ])
+        return q_values.masked_fill(~stacked_masks, float("-inf"))
+
+    def _to_mask_tensor(
+        self,
+        mask: Union[Sequence[int], Sequence[bool], "Tensor"],
+        width: int,
+    ) -> "Tensor":
+        if torch is None:
+            raise RuntimeError("torch is required for mask conversion")
+
+        if isinstance(mask, torch.Tensor):
+            if mask.dtype == torch.bool:
+                tensor_mask = mask.to(self._device)
+            else:
+                tensor_mask = mask.to(self._device) > 0
+        else:
+            tensor_mask = torch.zeros(width, dtype=torch.bool, device=self._device)
+            try:
+                iterable = list(mask)  # type: ignore[arg-type]
+            except TypeError:
+                iterable = []
+
+            if iterable:
+                first = iterable[0]
+                if isinstance(first, bool):
+                    tensor_mask[: len(iterable)] = torch.tensor(iterable, dtype=torch.bool, device=self._device)
+                elif isinstance(first, int):
+                    for idx in iterable:
+                        if 0 <= int(idx) < width:
+                            tensor_mask[int(idx)] = True
+                elif isinstance(first, float):
+                    for idx, value in enumerate(iterable):
+                        if value > 0 and idx < width:
+                            tensor_mask[idx] = True
+                else:
+                    tensor_mask[:] = True
+            else:
+                tensor_mask[:] = True
+
+        if tensor_mask.shape[-1] != width:
+            padded = torch.zeros(width, dtype=torch.bool, device=self._device)
+            limit = min(width, tensor_mask.shape[-1])
+            padded[:limit] = tensor_mask[:limit]
+            tensor_mask = padded
+
+        if not torch.any(tensor_mask):
+            tensor_mask = torch.ones(width, dtype=torch.bool, device=self._device)
+
+        return tensor_mask
+
+    def _ensure_tensor(self, value: Any) -> "Tensor":
+        if torch is None:
+            raise RuntimeError("torch is required for tensor conversion")
+
+        if isinstance(value, torch.Tensor):
+            return value.to(self._device)
+
+        return torch.as_tensor(value, dtype=torch.float32, device=self._device)

--- a/python/rl_combat/training/encoders.py
+++ b/python/rl_combat/training/encoders.py
@@ -1,0 +1,74 @@
+"""Utilities for converting encoded combat observations into tensors."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+from .. import bindings
+from ..observation import (
+    EncodedCombatObservation,
+    GLOBAL_FEATURE_COUNT,
+    STACK_FEATURE_COUNT,
+    flatten_observation,
+)
+
+try:  # Optional dependency; resolved lazily when used.
+    import torch
+    from torch import Tensor
+except ImportError:  # pragma: no cover - torch is optional for tooling installs
+    torch = None  # type: ignore
+    Tensor = Any  # type: ignore
+
+__all__ = [
+    "encoded_observation_size",
+    "encoded_observation_to_tensor",
+    "batch_observations_to_tensor",
+]
+
+
+def _ensure_torch() -> None:
+    if torch is None:
+        raise RuntimeError(
+            "torch is required to convert observations into tensors; "
+            "install torch or provide a custom encoder"
+        )
+
+
+def encoded_observation_size(
+    max_army_troops: Optional[int] = None,
+) -> int:
+    """Return the flattened observation dimension for a single snapshot."""
+
+    troops = max_army_troops or bindings.RL_COMBAT_MAX_ARMY_TROOPS
+    return GLOBAL_FEATURE_COUNT + 2 * troops * STACK_FEATURE_COUNT
+
+
+def encoded_observation_to_tensor(
+    observation: EncodedCombatObservation,
+    *,
+    device: Optional[str] = None,
+    dtype: Optional["torch.dtype"] = None,
+) -> "Tensor":
+    """Convert a single encoded observation into a 1D tensor."""
+
+    _ensure_torch()
+    vector = flatten_observation(observation)
+    tensor = torch.tensor(vector, device=device, dtype=dtype or torch.float32)  # type: ignore[attr-defined]
+    return tensor
+
+
+def batch_observations_to_tensor(
+    observations: Sequence[EncodedCombatObservation],
+    *,
+    device: Optional[str] = None,
+    dtype: Optional["torch.dtype"] = None,
+) -> "Tensor":
+    """Stack multiple encoded observations into a 2D tensor."""
+
+    if not observations:
+        raise ValueError("observations must contain at least one element")
+
+    _ensure_torch()
+    matrix = [flatten_observation(obs) for obs in observations]
+    tensor = torch.tensor(matrix, device=device, dtype=dtype or torch.float32)  # type: ignore[attr-defined]
+    return tensor

--- a/python/rl_combat/training/networks.py
+++ b/python/rl_combat/training/networks.py
@@ -1,0 +1,112 @@
+"""Neural network helpers for Clash of Fantasy combat training."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Sequence
+
+from .. import bindings
+from ..observation import GLOBAL_FEATURE_COUNT, STACK_FEATURE_COUNT
+from .dqn import DiscreteActionSpace
+
+try:  # Optional dependency; resolved at runtime for tooling without torch.
+    import torch
+    from torch import Tensor
+    import torch.nn as nn
+except ImportError:  # pragma: no cover - torch is optional for tooling installs
+    torch = None  # type: ignore
+    nn = None  # type: ignore
+    Tensor = Any  # type: ignore
+
+__all__ = [
+    "combat_observation_dim",
+    "CombatMLP",
+    "build_mlp_q_network",
+]
+
+
+def _ensure_torch_nn() -> None:
+    if nn is None:
+        raise RuntimeError(
+            "torch is required to construct neural networks; "
+            "install torch or provide custom network implementations"
+        )
+
+
+def combat_observation_dim(max_army_troops: Optional[int] = None) -> int:
+    """Return the flattened observation dimension consumed by MLP models."""
+
+    troops = max_army_troops or bindings.RL_COMBAT_MAX_ARMY_TROOPS
+    return GLOBAL_FEATURE_COUNT + 2 * troops * STACK_FEATURE_COUNT
+
+
+if nn is not None:
+
+    class CombatMLP(nn.Module):
+        """Simple fully-connected network for approximating combat Q-values."""
+
+        def __init__(
+            self,
+            input_dim: int,
+            output_dim: int,
+            *,
+            hidden_layers: Sequence[int] = (256, 128),
+            activation: Optional[Callable[[], "nn.Module"]] = None,
+            layer_norm: bool = False,
+        ) -> None:
+            _ensure_torch_nn()
+            super().__init__()
+
+            act_factory: Callable[[], "nn.Module"]
+            if activation is None:
+                act_factory = nn.ReLU  # type: ignore[assignment]
+            else:
+                act_factory = activation
+
+            layers: list["nn.Module"] = []
+            last_dim = input_dim
+            for hidden in hidden_layers:
+                if hidden <= 0:
+                    continue
+                layers.append(nn.Linear(last_dim, hidden))
+                if layer_norm:
+                    layers.append(nn.LayerNorm(hidden))
+                layers.append(act_factory())
+                last_dim = hidden
+
+            layers.append(nn.Linear(last_dim, output_dim))
+            self.model = nn.Sequential(*layers)
+
+        def forward(self, inputs: "Tensor") -> "Tensor":  # type: ignore[override]
+            return self.model(inputs)
+
+else:
+
+    class CombatMLP:  # type: ignore[misc]
+        """Placeholder that raises if torch is unavailable."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401 - runtime guard
+            _ensure_torch_nn()
+
+        def forward(self, inputs: Any) -> Any:
+            _ensure_torch_nn()
+
+
+def build_mlp_q_network(
+    action_space: DiscreteActionSpace,
+    *,
+    input_dim: Optional[int] = None,
+    hidden_layers: Sequence[int] = (256, 128),
+    activation: Optional[Callable[[], "nn.Module"]] = None,
+    layer_norm: bool = False,
+) -> "CombatMLP":
+    """Construct a default CombatMLP sized to the action space."""
+
+    _ensure_torch_nn()
+    dim = input_dim or combat_observation_dim()
+    return CombatMLP(
+        dim,
+        action_space.size,
+        hidden_layers=hidden_layers,
+        activation=activation,
+        layer_norm=layer_norm,
+    )

--- a/python/rl_combat/training/policies.py
+++ b/python/rl_combat/training/policies.py
@@ -1,0 +1,53 @@
+"""Policy abstractions for driving self-play simulations."""
+
+from __future__ import annotations
+
+import random
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Optional, Sequence
+
+from ..session import CombatAction, CombatActionType
+
+
+class BasePolicy(ABC):
+    """Interface for policies that emit environment-compatible actions."""
+
+    @abstractmethod
+    def select_action(
+        self,
+        observation: Any,
+        *,
+        legal_actions: Optional[Iterable[CombatActionType]] = None,
+    ) -> CombatAction:
+        """Return a `CombatAction` in response to an observation."""
+
+
+class RandomPolicy(BasePolicy):
+    """Uniformly sample from the provided legal action set."""
+
+    def __init__(self, *, rng: Optional[random.Random] = None) -> None:
+        self._rng = rng or random.Random()
+
+    def select_action(
+        self,
+        observation: Any,
+        *,
+        legal_actions: Optional[Iterable[CombatActionType]] = None,
+    ) -> CombatAction:
+        del observation  # unused but part of the interface
+
+        candidates: Sequence[CombatActionType]
+        if legal_actions:
+            candidates = tuple(legal_actions)
+        else:
+            candidates = (
+                CombatActionType.WAIT,
+                CombatActionType.DEFEND,
+                CombatActionType.AUTO_RESOLVE,
+            )
+
+        if not candidates:
+            raise ValueError("No legal actions provided to RandomPolicy")
+
+        choice = self._rng.choice(candidates)
+        return CombatAction(choice)

--- a/python/rl_combat/training/replay_buffer.py
+++ b/python/rl_combat/training/replay_buffer.py
@@ -1,0 +1,68 @@
+"""Experience replay utilities used by the training loops."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Deque, Iterable, List, Optional
+
+import random
+
+
+@dataclass
+class Transition:
+    """Container describing a single environment transition."""
+
+    state: Any
+    action: int
+    reward: float
+    next_state: Any
+    done: bool
+    legal_actions_mask: Optional[Any] = None
+    next_legal_actions_mask: Optional[Any] = None
+
+
+class ReplayBuffer:
+    """Fixed-capacity buffer for sampling i.i.d. batches of transitions."""
+
+    def __init__(
+        self,
+        capacity: int,
+        *,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._capacity = capacity
+        self._data: Deque[Transition] = deque(maxlen=capacity)
+        self._rng = rng or random.Random()
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    def clear(self) -> None:
+        self._data.clear()
+
+    def extend(self, transitions: Iterable[Transition]) -> None:
+        for transition in transitions:
+            self.append(transition)
+
+    def append(self, transition: Transition) -> None:
+        self._data.append(transition)
+
+    def sample(self, batch_size: int) -> List[Transition]:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if batch_size > len(self._data):
+            raise ValueError("Cannot sample more elements than present in buffer")
+        return self._rng.sample(list(self._data), batch_size)
+
+    def is_full(self) -> bool:
+        return len(self._data) >= self._capacity
+
+    def ready_for_training(self, minimum_size: int) -> bool:
+        return len(self._data) >= minimum_size

--- a/python/rl_combat/training/run.py
+++ b/python/rl_combat/training/run.py
@@ -1,0 +1,380 @@
+"""Command-line helpers for running basic combat DQN training loops."""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from ..environment import CombatEnvironment, ControlledSide
+from ..observation import EncodedCombatObservation
+from ..scenario import CombatScenario, HeroLoadout, TroopStack
+from ..session import CombatAction, CombatActionType, StackObservation
+from .config import DQNConfig
+from .dqn import DQNTrainer, DiscreteActionSpace, EpsilonSchedule
+from .encoders import encoded_observation_to_tensor
+from .networks import build_mlp_q_network, combat_observation_dim
+from .replay_buffer import ReplayBuffer
+
+try:  # torch is an optional dependency for the base package
+    import torch
+    from torch.optim import Adam
+except ImportError:  # pragma: no cover - handled at runtime
+    torch = None  # type: ignore[assignment]
+    Adam = None  # type: ignore[assignment]
+
+__all__ = [
+    "build_default_scenario",
+    "create_environment_factory",
+    "main",
+]
+
+_DEFAULT_ATTACKER_UNIT = 16  # UNIT_INFANTRYMAN
+_DEFAULT_DEFENDER_UNIT = 16  # UNIT_INFANTRYMAN
+_DEFAULT_STACK_SIZE = 20
+
+
+def build_default_scenario(
+    rng: random.Random,
+    options: Optional[Mapping[str, Any]] = None,
+) -> CombatScenario:
+    """Return a simple duel scenario for quick smoke tests."""
+
+    opts = dict(options or {})
+    attacker_unit = int(opts.get("attacker_unit_type", _DEFAULT_ATTACKER_UNIT))
+    defender_unit = int(opts.get("defender_unit_type", _DEFAULT_DEFENDER_UNIT))
+    base_attacker_stack = int(opts.get("attacker_stack_size", _DEFAULT_STACK_SIZE))
+    base_defender_stack = int(opts.get("defender_stack_size", _DEFAULT_STACK_SIZE))
+    variation = int(opts.get("stack_size_variation", 0))
+
+    if variation > 0:
+        attacker_delta = rng.randint(-variation, variation)
+        defender_delta = rng.randint(-variation, variation)
+    else:
+        attacker_delta = 0
+        defender_delta = 0
+
+    attacker_stack = max(1, base_attacker_stack + attacker_delta)
+    defender_stack = max(1, base_defender_stack + defender_delta)
+
+    attacker = HeroLoadout(
+        player=1,
+        hero_class=0,
+        hero_id=0,
+        name="RL Attacker",
+        level=1,
+        attack=2,
+        defense=2,
+        power=1,
+        knowledge=1,
+        mana=12,
+        human_controlled=True,
+        troops=(TroopStack(unit_type=attacker_unit, stack_size=attacker_stack),),
+    )
+    defender = HeroLoadout(
+        player=2,
+        hero_class=0,
+        hero_id=0,
+        name="RL Defender",
+        level=1,
+        attack=2,
+        defense=2,
+        power=1,
+        knowledge=1,
+        mana=12,
+        human_controlled=True,
+        troops=(TroopStack(unit_type=defender_unit, stack_size=defender_stack),),
+    )
+
+    environment = int(opts.get("environment", 0))
+    quick_combat = bool(opts.get("quick_combat", False))
+    is_deathmatch = bool(opts.get("is_deathmatch", False))
+
+    return CombatScenario(
+        attacker=attacker,
+        defender=defender,
+        environment=environment,
+        quick_combat=quick_combat,
+        is_deathmatch=is_deathmatch,
+    )
+
+
+def create_environment_factory(
+    *,
+    library_path: Optional[str],
+    scenario_options: Optional[Mapping[str, Any]] = None,
+) -> Callable[[ControlledSide], CombatEnvironment]:
+    """Build a factory that produces combat environments on demand."""
+
+    options = dict(scenario_options or {})
+
+    def scenario_generator(rng: random.Random, user_options: Optional[Mapping[str, Any]] = None) -> CombatScenario:
+        merged = dict(options)
+        if user_options:
+            merged.update(user_options)
+        return build_default_scenario(rng, merged)
+
+    def factory(side: ControlledSide) -> CombatEnvironment:
+        return CombatEnvironment(
+            scenario_generator,
+            controlled_side=ControlledSide(side),
+            library_path=library_path,
+        )
+
+    return factory
+
+
+def _build_action_space() -> DiscreteActionSpace:
+    return DiscreteActionSpace(
+        actions=(
+            CombatAction(CombatActionType.WAIT),
+            CombatAction(CombatActionType.DEFEND),
+            CombatAction(CombatActionType.AUTO_RESOLVE),
+        )
+    )
+
+
+def _find_active_stack(observation: EncodedCombatObservation) -> Optional[StackObservation]:
+    raw = observation.raw
+    if raw.active_unit_id < 0:
+        return None
+
+    active_side = raw.active_unit_is_attacker
+    if active_side is None:
+        return None
+
+    active_position = tuple(raw.active_unit_position)
+    stacks = raw.attacker_stacks if active_side else raw.defender_stacks
+    for stack in stacks:
+        if tuple(stack.position) == active_position:
+            return stack
+
+    return None
+
+
+def _legal_action_mask(observation: EncodedCombatObservation) -> Sequence[bool]:
+    """Return a mask indicating which discrete actions are currently valid."""
+
+    active_stack = _find_active_stack(observation)
+    if active_stack is None:
+        # When no unit is active we can only request auto-resolve to let the
+        # simulator advance until a new decision is required.
+        return (False, False, True)
+
+    if not active_stack.is_alive or active_stack.is_disabled:
+        return (False, False, True)
+
+    can_wait = not active_stack.has_waited
+    can_defend = not active_stack.has_defended
+
+    # Auto-resolve is always available as a fallback.
+    return (can_wait, can_defend, True)
+
+
+def _resolve_hidden_layers(values: Optional[Sequence[int]]) -> Sequence[int]:
+    if not values:
+        return (256, 128)
+    return tuple(int(v) for v in values if int(v) > 0)
+
+
+def _make_observation_encoder(device: Optional[str]) -> Callable[[EncodedCombatObservation], "torch.Tensor"]:
+    if torch is None:
+        raise RuntimeError("PyTorch is required to encode observations for training")
+
+    def encoder(observation: EncodedCombatObservation) -> "torch.Tensor":
+        return encoded_observation_to_tensor(observation, device=device)
+
+    return encoder
+
+
+def _create_trainer(args: argparse.Namespace) -> DQNTrainer:
+    if torch is None or Adam is None:
+        raise RuntimeError(
+            "PyTorch is required to run training. Install torch before executing this script."
+        )
+
+    action_space = _build_action_space()
+    hidden_layers = _resolve_hidden_layers(args.hidden_layer)
+    config = DQNConfig(
+        discount=args.discount,
+        batch_size=args.batch_size,
+        minimum_buffer_size=args.minimum_buffer,
+        training_frequency=args.training_frequency,
+        target_update_frequency=args.target_update,
+        gradient_clip_norm=args.gradient_clip,
+        max_steps_per_episode=args.max_steps,
+        replay_buffer_capacity=args.buffer_capacity,
+    )
+
+    replay_buffer = ReplayBuffer(config.replay_buffer_capacity, rng=random.Random(args.seed))
+
+    policy_net = build_mlp_q_network(
+        action_space,
+        input_dim=combat_observation_dim(),
+        hidden_layers=hidden_layers,
+        layer_norm=args.layer_norm,
+    )
+    target_net = build_mlp_q_network(
+        action_space,
+        input_dim=combat_observation_dim(),
+        hidden_layers=hidden_layers,
+        layer_norm=args.layer_norm,
+    )
+
+    optimizer = Adam(policy_net.parameters(), lr=args.learning_rate)
+
+    env_factory = create_environment_factory(
+        library_path=args.library,
+        scenario_options=args.scenario_option,
+    )
+
+    epsilon_schedule = EpsilonSchedule(
+        start=args.epsilon_start,
+        end=args.epsilon_end,
+        decay_steps=args.epsilon_decay,
+    )
+
+    observation_encoder = _make_observation_encoder(args.device)
+
+    rng = random.Random(args.seed) if args.seed is not None else None
+
+    trainer = DQNTrainer(
+        policy_network=policy_net,
+        target_network=target_net,
+        optimizer=optimizer,
+        replay_buffer=replay_buffer,
+        env_factory=env_factory,
+        observation_encoder=observation_encoder,
+        action_space=action_space,
+        legal_action_fn=_legal_action_mask,
+        config=config,
+        epsilon_schedule=epsilon_schedule,
+        policy_side=ControlledSide(args.side),
+        device=args.device,
+        rng=rng,
+    )
+
+    return trainer
+
+
+def _print_summary(metrics: Any) -> None:
+    print(f"Completed {len(metrics.episode_rewards)} episodes / {metrics.total_steps} environment steps")
+    if metrics.episode_rewards:
+        reward_mean = statistics.mean(metrics.episode_rewards)
+        reward_std = statistics.pstdev(metrics.episode_rewards) if len(metrics.episode_rewards) > 1 else 0.0
+        print(f"Episode reward: mean={reward_mean:.3f} std={reward_std:.3f}")
+    if metrics.losses:
+        loss_mean = statistics.mean(metrics.losses)
+        print(f"Average loss: {loss_mean:.6f}")
+    if metrics.epsilon_values:
+        print(
+            f"Epsilon schedule: start={metrics.epsilon_values[0]:.3f} "
+            f"final={metrics.epsilon_values[-1]:.3f}"
+        )
+
+
+def _parse_scenario_options(option_values: Optional[Sequence[str]]) -> Mapping[str, Any]:
+    options: dict[str, Any] = {}
+    if not option_values:
+        return options
+
+    for raw in option_values:
+        if "=" not in raw:
+            raise ValueError(f"Scenario option '{raw}' must be of the form key=value")
+        key, value = raw.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError("Scenario option keys must be non-empty")
+        if value.lower() in {"true", "false"}:
+            options[key] = value.lower() == "true"
+            continue
+        try:
+            if "." in value:
+                options[key] = float(value)
+            else:
+                options[key] = int(value)
+            continue
+        except ValueError:
+            pass
+        options[key] = value
+    return options
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run a basic Clash of Fantasy combat DQN training loop")
+    parser.add_argument("--episodes", type=int, default=5, help="Number of training episodes to run")
+    parser.add_argument("--library", type=str, default=None, help="Path to libcof_core shared library")
+    parser.add_argument("--learning-rate", type=float, default=1e-3, help="Optimizer learning rate")
+    parser.add_argument("--batch-size", type=int, default=32, help="Training batch size")
+    parser.add_argument("--minimum-buffer", type=int, default=64, help="Minimum replay buffer size before training")
+    parser.add_argument("--buffer-capacity", type=int, default=10_000, help="Replay buffer capacity")
+    parser.add_argument("--training-frequency", type=int, default=1, help="How often to run optimisation steps")
+    parser.add_argument("--target-update", type=int, default=250, help="Target network update frequency")
+    parser.add_argument("--max-steps", type=int, default=128, help="Maximum steps per episode")
+    parser.add_argument("--discount", type=float, default=0.99, help="Discount factor for future rewards")
+    parser.add_argument("--gradient-clip", type=float, default=5.0, help="Gradient clipping norm")
+    parser.add_argument("--device", type=str, default=None, help="Torch device to run on (e.g. 'cpu' or 'cuda')")
+    parser.add_argument("--hidden-layer", type=int, action="append", help="Add a hidden layer width to the MLP")
+    parser.add_argument("--layer-norm", action="store_true", help="Apply layer norm after each hidden layer")
+    parser.add_argument("--epsilon-start", type=float, default=1.0, help="Initial epsilon for epsilon-greedy exploration")
+    parser.add_argument("--epsilon-end", type=float, default=0.05, help="Final epsilon value")
+    parser.add_argument("--epsilon-decay", type=int, default=5_000, help="Steps to anneal epsilon")
+    parser.add_argument("--side", choices=[side.value for side in ControlledSide], default=ControlledSide.ATTACKER.value, help="Which side the policy controls")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument(
+        "--scenario-option",
+        action="append",
+        help="Override default scenario parameters (key=value). Can be supplied multiple times.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if torch is None or Adam is None:
+        parser.error("PyTorch is required to run this training script. Install torch and try again.")
+
+    if args.episodes <= 0:
+        parser.error("--episodes must be positive")
+
+    if args.batch_size <= 0:
+        parser.error("--batch-size must be positive")
+
+    if args.minimum_buffer <= 0:
+        parser.error("--minimum-buffer must be positive")
+
+    if args.buffer_capacity <= 0:
+        parser.error("--buffer-capacity must be positive")
+
+    if args.training_frequency <= 0:
+        parser.error("--training-frequency must be positive")
+
+    if args.target_update <= 0:
+        parser.error("--target-update must be positive")
+
+    if args.max_steps is not None and args.max_steps <= 0:
+        parser.error("--max-steps must be positive")
+
+    if not 0.0 <= args.epsilon_end <= args.epsilon_start <= 1.0:
+        parser.error("Require 0 <= epsilon_end <= epsilon_start <= 1")
+
+    args.scenario_option = _parse_scenario_options(args.scenario_option)
+
+    random.seed(args.seed)
+    if torch is not None and args.seed is not None:
+        torch.manual_seed(args.seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(args.seed)
+
+    trainer = _create_trainer(args)
+    metrics = trainer.train(args.episodes)
+    _print_summary(metrics)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/python/rl_combat/training/self_play.py
+++ b/python/rl_combat/training/self_play.py
@@ -1,0 +1,157 @@
+"""Self-play orchestration utilities for reinforcement-learning agents."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from ..environment import CombatEnvironment, ControlledSide
+from ..session import BattleResult, CombatAction
+from .config import SelfPlayConfig
+from .policies import BasePolicy
+
+
+@dataclass
+class EpisodeRecord:
+    """Full trajectory data for a single combat episode."""
+
+    controlled_side: ControlledSide
+    observations: List[Any] = field(default_factory=list)
+    actions: List[CombatAction] = field(default_factory=list)
+    rewards: List[float] = field(default_factory=list)
+    next_observations: List[Any] = field(default_factory=list)
+    dones: List[bool] = field(default_factory=list)
+    infos: List[Dict[str, Any]] = field(default_factory=list)
+    result: BattleResult = BattleResult.IN_PROGRESS
+
+    def __len__(self) -> int:
+        return len(self.actions)
+
+    def transitions(self) -> Iterable["Transition"]:
+        """Yield replay buffer transitions for downstream consumption."""
+
+        from .replay_buffer import Transition
+
+        for obs, action, reward, next_obs, done in zip(
+            self.observations,
+            self.actions,
+            self.rewards,
+            self.next_observations,
+            self.dones,
+        ):
+            yield Transition(
+                state=obs,
+                action=int(action.action_type),
+                reward=reward,
+                next_state=next_obs,
+                done=done,
+                legal_actions_mask=None,
+                next_legal_actions_mask=None,
+            )
+
+
+class SelfPlayRunner:
+    """Drive repeated combat episodes using a supplied policy."""
+
+    def __init__(
+        self,
+        env_factory: Callable[[ControlledSide], CombatEnvironment],
+        *,
+        config: Optional[SelfPlayConfig] = None,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        self._env_factory = env_factory
+        self._config = config or SelfPlayConfig()
+        self._rng = rng or random.Random(self._config.random_seed)
+        self._next_side = ControlledSide.ATTACKER
+
+    def run_episode(
+        self,
+        policy: BasePolicy,
+        *,
+        controlled_side: Optional[ControlledSide] = None,
+        scenario_options: Optional[Dict[str, Any]] = None,
+        seed: Optional[int] = None,
+        max_steps: Optional[int] = None,
+    ) -> EpisodeRecord:
+        side = controlled_side or self._select_side()
+
+        episode_seed = seed
+        if episode_seed is None and self._config.random_seed is not None:
+            episode_seed = self._rng.randint(0, 2**31 - 1)
+
+        env = self._env_factory(side)
+        with env:
+            options = dict(self._config.scenario_options)
+            if scenario_options:
+                options.update(scenario_options)
+
+            observation, _ = env.reset(seed=episode_seed, options=options)
+
+            record = EpisodeRecord(controlled_side=side)
+            terminated = False
+            steps = 0
+            max_episode_steps = max_steps
+            if max_episode_steps is None:
+                max_episode_steps = self._config.max_steps_per_episode
+
+            while not terminated:
+                action = policy.select_action(observation)
+                next_observation, reward, terminated, truncated, step_info = env.step(action)
+
+                record.observations.append(observation)
+                record.actions.append(action)
+                record.rewards.append(float(reward))
+                record.next_observations.append(next_observation)
+                record.dones.append(bool(terminated or truncated))
+                record.infos.append(step_info)
+
+                observation = next_observation
+                steps += 1
+
+                if max_episode_steps is not None and steps >= max_episode_steps:
+                    break
+
+                if truncated:
+                    break
+
+            record.result = (
+                BattleResult(record.infos[-1]["battle_result"])
+                if record.infos
+                else BattleResult.IN_PROGRESS
+            )
+
+        if self._config.alternate_controlled_side and controlled_side is None:
+            self._next_side = (
+                ControlledSide.DEFENDER
+                if side is ControlledSide.ATTACKER
+                else ControlledSide.ATTACKER
+            )
+
+        return record
+
+    def run_batch(
+        self,
+        policy: BasePolicy,
+        *,
+        episodes: Optional[int] = None,
+        scenario_options: Optional[Dict[str, Any]] = None,
+    ) -> List[EpisodeRecord]:
+        total = episodes or self._config.episodes_per_cycle
+        results: List[EpisodeRecord] = []
+        for _ in range(total):
+            record = self.run_episode(policy, scenario_options=scenario_options)
+            results.append(record)
+        return results
+
+    def _select_side(self) -> ControlledSide:
+        if not self._config.alternate_controlled_side:
+            return self._next_side
+        side = self._next_side
+        self._next_side = (
+            ControlledSide.DEFENDER
+            if self._next_side is ControlledSide.ATTACKER
+            else ControlledSide.ATTACKER
+        )
+        return side


### PR DESCRIPTION
## Summary
- ensure combat scenarios mark only the controlled hero as human and auto-play opposing turns before presenting observations
- add an observation helper that advances the engine until the agent’s side is active so each step returns a decision-ready state
- teach the DQN trainer to honour terminal resets by reading the environment info before entering the episode loop
- add a simple legal-action mask so the training runner avoids issuing already-spent wait/defend commands

## Testing
- python -m compileall python/rl_combat

------
https://chatgpt.com/codex/tasks/task_e_68d4bbecb388832d9d935996d1f4634e