### PR TITLE
Auto-place summons, fix healing/resurrection edge cases, and add tests

### DIFF
--- a/game/src/core/battlefield.cpp
+++ b/game/src/core/battlefield.cpp
@@ -6,6 +6,7 @@
 
 #include <deque>
 #include <algorithm>
+#include <limits>
 #include <random>
 #include <queue>
 
@@ -619,6 +620,37 @@ uint battlefield_t::get_two_hex_effective_x(const battlefield_unit_t& unit, uint
 	}
 
 	return target_x;
+}
+
+battlefield_hex_t* battlefield_t::get_open_position_closest_to_caster(bool caster_is_attacker, const battlefield_unit_t& unit) {
+	const int start_x = caster_is_attacker ? 0 : game_config::BATTLEFIELD_WIDTH - 1;
+	const int start_y = 3;
+	const int tail_direction = caster_is_attacker ? -1 : 1;
+
+	battlefield_hex_t* best_hex = nullptr;
+	int best_distance = std::numeric_limits<int>::max();
+
+	for(int y = 0; y < static_cast<int>(game_config::BATTLEFIELD_HEIGHT); ++y) {
+		for(int x = 0; x < static_cast<int>(game_config::BATTLEFIELD_WIDTH); ++x) {
+			auto hex = hex_grid.get_hex(x, y);
+			if(!hex || !hex->passable || hex->unit)
+				continue;
+
+			if(unit.is_two_hex()) {
+				auto tail_hex = hex_grid.get_hex(x + tail_direction, y);
+				if(!tail_hex || !tail_hex->passable || tail_hex->unit)
+					continue;
+			}
+
+			const int distance = hex_grid.distance(start_x, start_y, x, y);
+			if(distance < best_distance) {
+				best_distance = distance;
+				best_hex = hex;
+			}
+		}
+	}
+
+	return best_hex;
 }
 
 bool battlefield_t::is_move_valid(battlefield_unit_t &unit, uint target_x, uint target_y) {
@@ -2028,6 +2060,11 @@ spell_result_e battlefield_t::cast_spell(hero_t* caster, spell_e spell_id, int t
 			summoned_unit.unit_health = get_unit_adjusted_hp(summoned_unit);
 			summoned_unit.was_summoned = true;
 			summoned_unit.is_attacker = (caster == attacking_hero);
+
+			auto summon_hex = get_open_position_closest_to_caster(summoned_unit.is_attacker, summoned_unit);
+			if(!summon_hex)
+				return SPELL_RESULT_INVALID_TARGET;
+
 			int pos = 0;
 			for(; pos < caster_troops.size(); pos++) {
 				if(caster_troops[pos].unit_type == UNIT_UNKNOWN)
@@ -2048,8 +2085,9 @@ spell_result_e battlefield_t::cast_spell(hero_t* caster, spell_e spell_id, int t
 			}
 
 			summoned_unit.troop_id = ++id;
-			summoned_unit.x = 3;
-			summoned_unit.y = 3;
+			summoned_unit.x = summon_hex->x;
+			summoned_unit.y = summon_hex->y;
+			action.target_hex = make_hex_location(summon_hex->x, summon_hex->y);
 
 			caster_troops[pos] = summoned_unit;
 			
@@ -3995,6 +4033,9 @@ std::pair<uint32_t, uint16_t> battlefield_t::calculate_healing_to_stack(hero_t* 
 }
 
 std::pair<uint32_t, uint16_t> battlefield_t::apply_healing_to_stack(uint32_t healing, battlefield_unit_t& unit, bool can_resurrect, bool simulate) {
+	if(healing == 0)
+		return {0, 0};
+
 	bool was_dead = (unit.stack_size == 0);
 
 	uint32_t adjusted_healing = healing;
@@ -4029,7 +4070,7 @@ std::pair<uint32_t, uint16_t> battlefield_t::apply_healing_to_stack(uint32_t hea
 			unit.unit_health = unit_max_hp;
 		}
 
-		if(was_dead) {
+		if(was_dead && new_stack_size > 0) {
 			auto unit_hex = hex_grid.get_hex(unit.x, unit.y);
 			if(unit_hex->unit != nullptr)
 				throw;
@@ -4888,10 +4929,20 @@ bool battlefield_t::is_unit_immune_to_spell(const battlefield_unit_t* unit, spel
 }
 
 bool battlefield_t::is_spell_target_valid(hero_t* caster, int target_x, int target_y, spell_e spell_id) {
-	if(!caster || !hex_grid.get_hex(target_x, target_y) || spell_id == SPELL_UNKNOWN)
+	if(!caster || spell_id == SPELL_UNKNOWN)
 		return false;
 
 	const auto& spell_info = game_config::get_spell(spell_id);
+	if(spell_info.target == TARGET_SUMMON) {
+		battlefield_unit_t summoned_unit;
+		summoned_unit.unit_type = UNIT_EFREETI;
+		summoned_unit.is_attacker = (caster == attacking_hero);
+		return get_open_position_closest_to_caster(summoned_unit.is_attacker, summoned_unit) != nullptr;
+	}
+
+	if(!hex_grid.get_hex(target_x, target_y))
+		return false;
+
 	switch(spell_info.target) { 
 		case TARGET_NONE:
 			return false;

--- a/game/src/core/battlefield.h
+++ b/game/src/core/battlefield.h
@@ -540,6 +540,7 @@ struct battlefield_t {
 	std::pair<battlefield_unit_t*, battlefield_hex_t*> get_nearest_target(battlefield_unit_t* acting_unit, bool include_friendly = false, bool ignore_range = false);
 	battlefield_hex_t* get_target_movement_hex(battlefield_unit_t* acting_unit);
 	uint get_two_hex_effective_x(const battlefield_unit_t& unit, uint target_x, uint target_y);
+	battlefield_hex_t* get_open_position_closest_to_caster(bool caster_is_attacker, const battlefield_unit_t& unit);
 	std::vector<battlefield_unit_t*> get_chain_lightning_targets(battlefield_unit_t* initial_target, int jump_count);
 	bool is_move_valid(battlefield_unit_t& unit, uint target_x, uint target_y);
 	bool is_spell_target_valid(hero_t* caster, battlefield_unit_t* unit, spell_e spell_id);

--- a/tests/combat_core_tests.cpp
+++ b/tests/combat_core_tests.cpp
@@ -38,6 +38,12 @@ void place_unit(battlefield_t& battlefield, battlefield_unit_t& unit) {
         battlefield.hex_grid.get_hex(unit.x, unit.y)->unit = &unit;
 }
 
+void place_two_hex_unit(battlefield_t& battlefield, battlefield_unit_t& unit) {
+        place_unit(battlefield, unit);
+        const int tail_direction = unit.is_attacker ? -1 : 1;
+        battlefield.hex_grid.get_hex(unit.x + tail_direction, unit.y)->unit = &unit;
+}
+
 void assign_army_unit(army_t& army, std::size_t slot, battlefield_unit_t unit) {
         army.troops[slot] = unit;
 }
@@ -112,6 +118,24 @@ void test_healing_simulate_and_resurrect() {
         expect_eq(resurrected.second, static_cast<uint16_t>(1), "healing a dead stack should resurrect one unit when enough healing is supplied");
         expect_eq(unit.stack_size, static_cast<uint16_t>(1), "resurrected stack should contain one unit");
         expect_true(battlefield.hex_grid.get_hex(4, 4)->unit == &unit, "resurrected stack should be restored to the hex grid");
+}
+
+void test_dead_stack_zero_healing_does_not_reoccupy_hex() {
+        battlefield_t battlefield;
+        battlefield.fn_emit_combat_action = [](const battle_action_t&) {};
+        battlefield_unit_t unit = make_unit(UNIT_SKELETON, 1, true, 2, 4, 4);
+        unit.original_stack_size = 1;
+        place_unit(battlefield, unit);
+
+        battlefield.deal_damage_to_stack(9999, unit);
+        expect_eq(unit.stack_size, static_cast<uint16_t>(0), "test setup should kill the stack");
+        expect_true(battlefield.hex_grid.get_hex(4, 4)->unit == nullptr, "dead stack should be removed before zero healing");
+
+        const auto healed = battlefield.apply_healing_to_stack(0, unit, true, false);
+        expect_eq(healed.first, static_cast<uint32_t>(0), "zero healing should report no healing");
+        expect_eq(healed.second, static_cast<uint16_t>(0), "zero healing should report no resurrected units");
+        expect_eq(unit.stack_size, static_cast<uint16_t>(0), "zero healing should leave the stack dead");
+        expect_true(battlefield.hex_grid.get_hex(4, 4)->unit == nullptr, "zero healing should not put a dead stack back on the hex grid");
 }
 
 void test_healing_exact_edge_cases_from_regression_suite() {
@@ -288,6 +312,61 @@ void test_movement_shooting_and_retaliation_rules() {
         expect_true(archer.add_buff(BUFF_NO_ENEMY_RETALIATION), "test setup should add no-retaliation buff");
         expect_true(!battlefield.will_defender_retaliate(archer, enemy), "attacker no-retaliation buff should suppress retaliation");
 }
+
+void test_resurrection_targeting_rejects_blocked_two_hex_corpse() {
+        battlefield_t battlefield;
+        battlefield.fn_emit_combat_action = [](const battle_action_t&) {};
+        hero_t attacker;
+        hero_t defender;
+        battlefield.attacking_hero = &attacker;
+        battlefield.defending_hero = &defender;
+
+        battlefield_unit_t abomination = make_unit(UNIT_ABOMINATION, 3, true, 0, 5, 5);
+        abomination.original_stack_size = 3;
+        place_two_hex_unit(battlefield, abomination);
+        battlefield.deal_damage_to_stack(9999, abomination);
+        expect_eq(abomination.stack_size, static_cast<uint16_t>(0), "test setup should create a two-hex corpse");
+
+        battlefield_unit_t blocker = make_unit(UNIT_SKELETON, 10, false, 3, 4, 5);
+        place_unit(battlefield, blocker);
+
+        expect_true(!battlefield.is_spell_target_valid(&attacker, &abomination, SPELL_RESURRECTION),
+                    "resurrection should be invalid when a two-hex corpse's tail is blocked by another unit");
+}
+
+void test_summon_spell_auto_places_near_caster_and_rejects_when_full() {
+        battlefield_t battlefield;
+        battlefield.fn_emit_combat_action = [](const battle_action_t&) {};
+        hero_t attacker;
+        attacker.mana = 100;
+        attacker.spellbook.push_back(SPELL_SUMMON_EFREET);
+        battlefield.attacking_hero = &attacker;
+
+        battlefield_unit_t blocker = make_unit(UNIT_SKELETON, 10, false, 7, 3, 3);
+        place_unit(battlefield, blocker);
+
+        expect_eq(battlefield.cast_spell(&attacker, SPELL_SUMMON_EFREET), SPELL_RESULT_OK,
+                  "summon should succeed without requiring a target hex");
+        auto summoned = battlefield.attacking_army.troops[0];
+        expect_true(summoned.was_summoned, "summon should fill the first open friendly troop slot");
+        expect_true(battlefield.hex_grid.get_hex(summoned.x, summoned.y)->unit == &battlefield.attacking_army.troops[0],
+                    "summon should occupy the automatically selected open hex");
+        expect_true(battlefield.hex_grid.get_hex(3, 3)->unit == &blocker, "summon should not overwrite occupied hexes while auto-placing");
+
+        battlefield_t full_battlefield;
+        full_battlefield.fn_emit_combat_action = [](const battle_action_t&) {};
+        hero_t full_attacker;
+        full_attacker.mana = 100;
+        full_attacker.spellbook.push_back(SPELL_SUMMON_EFREET);
+        full_battlefield.attacking_hero = &full_attacker;
+        for(uint y = 0; y < game_config::BATTLEFIELD_HEIGHT; ++y) {
+                for(uint x = 0; x < game_config::BATTLEFIELD_WIDTH; ++x)
+                        full_battlefield.hex_grid.get_hex(x, y)->passable = false;
+        }
+        full_attacker.mana = 100;
+        expect_eq(full_battlefield.cast_spell(&full_attacker, SPELL_SUMMON_EFREET), SPELL_RESULT_INVALID_TARGET,
+                  "summon should fail when no passable open hex is available");
+}
 }
 
 int main() {
@@ -296,7 +375,7 @@ int main() {
                 config_root = config_root.parent_path();
 
         const auto config_prefix = config_root.string() + "/";
-        if(game_config::load_buffs(config_prefix) != 0 || game_config::load_creatures(config_prefix) != 0) {
+        if(game_config::load_buffs(config_prefix) != 0 || game_config::load_creatures(config_prefix) != 0 || game_config::load_spells(config_prefix) != 0) {
                 std::cerr << "FAIL: required combat config failed to load\n";
                 return EXIT_FAILURE;
         }
@@ -304,12 +383,15 @@ int main() {
         test_buff_lifecycle_and_disabled_state();
         test_damage_kills_and_clears_hex();
         test_healing_simulate_and_resurrect();
+        test_dead_stack_zero_healing_does_not_reoccupy_hex();
         test_healing_exact_edge_cases_from_regression_suite();
         test_damage_prediction_and_adjusted_stats_are_bounded();
         test_turn_queue_orders_by_adjusted_initiative_speed_and_troop_bar();
         test_wait_queue_uses_adjusted_reverse_order();
         test_wait_unit_requeues_active_unit_after_non_waiters();
         test_movement_shooting_and_retaliation_rules();
+        test_resurrection_targeting_rejects_blocked_two_hex_corpse();
+        test_summon_spell_auto_places_near_caster_and_rejects_when_full();
 
         if(failures != 0) {
                 std::cerr << failures << " combat core test(s) failed.\n";


### PR DESCRIPTION
### Motivation
- Automatically place summoned units on the nearest open hex to the caster and ensure summoning fails when no valid open hex exists.
- Prevent dead stacks from being re-placed on the map when zero healing is applied and ensure resurrection validation accounts for two-hex corpses whose tail is blocked.
- Add unit tests to cover the new placement and healing/resurrection edge cases.

### Description
- Added `get_open_position_closest_to_caster(bool, const battlefield_unit_t&)` and declared it in `battlefield.h`, and included `<limits>` for distance inf handling.
- Updated summon handling in `cast_spell` to auto-select an open hex via `get_open_position_closest_to_caster`, set the summoned unit's position and `action.target_hex`, and return `SPELL_RESULT_INVALID_TARGET` if no valid hex exists.
- Extended `is_spell_target_valid` to handle `TARGET_SUMMON` by checking for an available open hex for the summoned unit, and adjusted hex-null checks accordingly.
- Fixed healing/resurrection logic in `apply_healing_to_stack` by returning early for zero healing and only reassigning hex occupancy when a dead stack is actually resurrected (`was_dead && new_stack_size > 0`).
- Added test helpers (`place_two_hex_unit`) and new tests in `tests/combat_core_tests.cpp`: `test_dead_stack_zero_healing_does_not_reoccupy_hex`, `test_resurrection_targeting_rejects_blocked_two_hex_corpse`, and `test_summon_spell_auto_places_near_caster_and_rejects_when_full`.
- Updated test runner to ensure `game_config::load_spells` is invoked during test setup.

### Testing
- Ran the combat core unit test binary (`tests/combat_core_tests`), which includes the existing suite plus the three new tests, and all tests passed.
- Verified spell-loading during test setup by adding `game_config::load_spells` to the test initialization, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a6bf06cd8832dafb58b2561d8f9b7)