### PR TITLE
Add combat achievement unit tests and integrate into achievement test runner

### DIFF
--- a/achievements_tests_progress.txt
+++ b/achievements_tests_progress.txt
@@ -1,0 +1,44 @@
+Achievement Tests Progress Report
+=================================
+
+Current test binaries
+---------------------
+- tests/achievement_tests.cpp: main achievement test runner plus adventure-map, construction, recruitment, and generic achievement semantics tests.
+- tests/combat_achievement_tests.cpp: combat-focused Magic and Might achievement tests that configure battlefield_t/game_t::battle state and drive game_t::accept_battle_results().
+
+Implemented achievement test coverage
+-------------------------------------
+Adventure map / economy / progression tests implemented:
+- Resource pickup acquisition achievements for gold, gems, mercury, crystals, wood, and ore.
+- Mine income acquisition achievements for ore, wood, gems, mercury, crystals, and gold.
+- Movement achievements for total hero travel, road travel, and terrain traversal.
+- Exploration achievements for fog reveal, watchtowers, keymaster tents, dimensional portals, Eye of the Magi, and full-map reveal sizes.
+- Construction achievements for core building categories, faction buildings, dwellings, forts/castles, marketplaces, turrets, and special buildings.
+- Recruitment achievements for all currently mapped recruitable unit achievements.
+- Generic achievement config validation, callback firing, threshold crossing, and one-shot semantics.
+
+Combat tests implemented:
+- ACHIEVEMENT_STORM_DRINKER has a concrete spell-cast scenario: a hero casts SPELL_LIGHTNING_BOLT against enemy troops, lightning damage is recorded, battle results are accepted, and the achievement callback is asserted.
+- All configured ACHIEVEMENT_TYPE_MAGIC achievements have explicit test cases.
+- All configured ACHIEVEMENT_TYPE_MIGHT achievements have explicit test cases.
+- Magic and Might combat-stat achievements are tested through battlefield_t/game_t::battle stats and game_t::accept_battle_results().
+- Magic and Might event achievements are tested through battlefield_t/game_t::battle conditions and game_t::accept_battle_results() where a gameplay combat-result path exists.
+
+Known passing state
+-------------------
+- The full achievement test suite passed locally with:
+  qmake tests/achievement_tests.pro -o /tmp/achievement_tests.Makefile && make -f /tmp/achievement_tests.Makefile -j2
+  (cd tests && ../achievement_tests)
+
+Known failing achievement tests
+-------------------------------
+- None currently known. The full achievement test suite passed in the latest local run.
+
+Still needs implementing / improving
+------------------------------------
+- Replace remaining synthetic combat-stat/event setup with concrete battlefield actions for each Magic and Might achievement where practical, similar to the new Storm Drinker Lightning Bolt scenario.
+- Add concrete spell-cast scenarios for the remaining elemental damage achievements: In Flames, Winter Is Coming, Earthshaker, Chaos Theory, and Blinded by the Light.
+- Add concrete scenarios for special Magic achievements such as Friendly Fire, Quenching the Flame, Conductive Critters, Meteoric Rise, Grave Mistake, Second Life, Creative Caster, Watch the World Burn, Master of the Arcane, and Energizer Bunny.
+- Add concrete combat-action scenarios for Might achievements such as Shot Through the Heart, Titanic Smackdown, The Bigger They Are..., Unbreakable, Outlast, High Roller, Maximum Overkill, and Crunching Numbers.
+- ACHIEVEMENT_TURTLING_UP currently has no live combat-result stat path in the core gameplay code; it is covered for achievement progress semantics but still needs gameplay implementation before a true battlefield scenario can be tested.
+- ACHIEVEMENT_ANCIENT_SECRETS is combat-adjacent via Pyramid battle rewards and is covered for progress semantics; a fuller integration test should drive a Pyramid battle reward flow.

--- a/tests/achievement_tests.cpp
+++ b/tests/achievement_tests.cpp
@@ -10,6 +10,8 @@
 
 #include <QBitArray>
 
+int run_combat_achievement_tests();
+
 namespace {
 int failures = 0;
 
@@ -501,6 +503,9 @@ void test_watchtower_exploration_progress_and_callbacks() {
         auto hero = make_hero(25, 25);
         auto* watchtower = add_object(game.map, 25, 25, OBJECT_WATCHTOWER);
         game.show_dialog_callback_fn = [](dialog_type_e, interactable_object_t*, hero_t*, int, int) {};
+        game.show_hero_levelup_callback_fn = [](hero_t*, skill_e, skill_e, skill_e, stat_e, bool) {};
+        game.game_event_callback_fn = [](game_state_update_e, player_e, int) {};
+        game.update_interactable_object_callback_fn = [](interactable_object_t*) {};
         std::vector<achievement_e> earned;
         game.achievement_earned_callback_fn = [&](achievement_e achievement) {
                 earned.push_back(achievement);
@@ -533,6 +538,9 @@ void test_keymaster_tent_progress_and_callback() {
         auto* tent = static_cast<keymaster_tent_t*>(add_object(game.map, 1, 1, OBJECT_KEYMASTER_TENT));
         tent->color = 2;
         game.show_dialog_callback_fn = [](dialog_type_e, interactable_object_t*, hero_t*, int, int) {};
+        game.show_hero_levelup_callback_fn = [](hero_t*, skill_e, skill_e, skill_e, stat_e, bool) {};
+        game.game_event_callback_fn = [](game_state_update_e, player_e, int) {};
+        game.update_interactable_object_callback_fn = [](interactable_object_t*) {};
         std::vector<achievement_e> earned;
         game.achievement_earned_callback_fn = [&](achievement_e achievement) {
                 earned.push_back(achievement);
@@ -689,6 +697,7 @@ void test_recruitment_achievement_progress_and_callbacks() {
         }
 }
 
+
 void test_achievement_config_is_well_formed() {
         const auto& achievements = game_config::get_achievements();
         expect_true(!achievements.empty(), "achievement config should load at least one achievement");
@@ -779,6 +788,10 @@ int main() {
                 std::cerr << "FAIL: could not load creatures config\n";
                 return EXIT_FAILURE;
         }
+        if(game_config::load_spells("../") != 0) {
+                std::cerr << "FAIL: could not load spells config\n";
+                return EXIT_FAILURE;
+        }
 
         test_achievement_config_is_well_formed();
         test_every_configured_achievement_can_fire_callback();
@@ -797,6 +810,7 @@ int main() {
         test_full_map_reveal_progress_and_callbacks();
         test_construction_achievement_progress_and_callbacks();
         test_recruitment_achievement_progress_and_callbacks();
+        failures += run_combat_achievement_tests();
 
         if(failures != 0) {
                 std::cerr << failures << " achievement test(s) failed.\n";

--- a/tests/achievement_tests.pro
+++ b/tests/achievement_tests.pro
@@ -12,6 +12,7 @@ PKGCONFIG += lua5.4
 LIBS += -llua5.4
 
 SOURCES += achievement_tests.cpp \
+           combat_achievement_tests.cpp \
            ../game/src/core/ai_adventure_map.cpp \
            ../game/src/core/ai_combat.cpp \
            ../game/src/core/adventure_map.cpp \

--- a/tests/combat_achievement_tests.cpp
+++ b/tests/combat_achievement_tests.cpp
@@ -1,0 +1,506 @@
+#include "core/game.h"
+#include "core/game_config.h"
+
+#include <algorithm>
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+int failures = 0;
+
+struct magic_combat_stat_achievement_case_t {
+        uint32_t combat_stats_t::* stat;
+        achievement_e achievement;
+};
+
+struct small_magic_combat_stat_achievement_case_t {
+        uint16_t combat_stats_t::* stat;
+        achievement_e achievement;
+};
+
+struct might_combat_stat_achievement_case_t {
+        uint32_t combat_stats_t::* stat;
+        achievement_e achievement;
+};
+
+struct small_might_combat_stat_achievement_case_t {
+        uint16_t combat_stats_t::* stat;
+        achievement_e achievement;
+};
+
+void expect_true(bool condition, const std::string& message) {
+        if(!condition) {
+                std::cerr << "FAIL: " << message << '\n';
+                ++failures;
+        }
+}
+
+void expect_eq(size_t actual, size_t expected, const std::string& message) {
+        if(actual != expected) {
+                std::cerr << "FAIL: " << message << " (expected " << expected << ", got " << actual << ")\n";
+                ++failures;
+        }
+}
+
+size_t earned_count(const std::vector<achievement_e>& earned, achievement_e achievement) {
+        return static_cast<size_t>(std::count(earned.begin(), earned.end(), achievement));
+}
+
+uint64_t first_threshold_or_one(const achievement_t& achievement) {
+        for(const auto& tier : achievement.tiers) {
+                if(tier.value > 0)
+                        return tier.value;
+        }
+        return 1;
+}
+
+battlefield_unit_t make_battlefield_unit(unit_type_e type, uint16_t stack_size, bool is_attacker, int8_t troop_id, int8_t x, int8_t y) {
+        battlefield_unit_t unit(troop_t(type, stack_size));
+        unit.is_attacker = is_attacker;
+        unit.troop_id = troop_id;
+        unit.x = x;
+        unit.y = y;
+        return unit;
+}
+
+void place_battlefield_unit(battlefield_t& battlefield, battlefield_unit_t& unit) {
+        battlefield.hex_grid.get_hex(unit.x, unit.y)->unit = &unit;
+}
+
+std::vector<small_magic_combat_stat_achievement_case_t> small_magic_combat_stat_achievement_cases() {
+        return {
+                {&combat_stats_t::genie_friendly_spells_cast, ACHIEVEMENT_I_DREAM_OF_GENIE},
+        };
+}
+
+std::vector<magic_combat_stat_achievement_case_t> magic_combat_stat_achievement_cases() {
+        return {
+                {&combat_stats_t::fire_spell_damage, ACHIEVEMENT_IN_FLAMES},
+                {&combat_stats_t::frost_spell_damage, ACHIEVEMENT_WINTER_IS_COMING},
+                {&combat_stats_t::lightning_spell_damage, ACHIEVEMENT_STORM_DRINKER},
+                {&combat_stats_t::earth_spell_damage, ACHIEVEMENT_EARTHSHAKER},
+                {&combat_stats_t::chaos_spell_damage, ACHIEVEMENT_CHAOS_THEORY},
+                {&combat_stats_t::holy_spell_damage, ACHIEVEMENT_BLINDED_BY_THE_LIGHT},
+        };
+}
+
+std::vector<small_might_combat_stat_achievement_case_t> small_might_combat_stat_achievement_cases() {
+        return {
+                {&combat_stats_t::total_critical_hits, ACHIEVEMENT_SHOT_THROUGH_THE_HEART},
+        };
+}
+
+std::vector<might_combat_stat_achievement_case_t> might_combat_stat_achievement_cases() {
+        return {
+                {&combat_stats_t::total_units_killed, ACHIEVEMENT_THE_REAPER},
+                {&combat_stats_t::max_damage_single_melee_attack, ACHIEVEMENT_ONE_PUNCH_HERO},
+        };
+}
+
+std::vector<achievement_e> might_event_achievement_cases() {
+        return {
+                ACHIEVEMENT_MAXED_OUT,
+                ACHIEVEMENT_GLASS_CANNON,
+                ACHIEVEMENT_IMMOVABLE_OBJECT,
+                ACHIEVEMENT_OVERMATCHED,
+                ACHIEVEMENT_EQUAL_GROUNDS,
+                ACHIEVEMENT_MASSACRE,
+                ACHIEVEMENT_TITANIC_SMACKDOWN,
+                ACHIEVEMENT_THE_BIGGER_THEY_ARE,
+                ACHIEVEMENT_UNBREAKABLE,
+                ACHIEVEMENT_OUTLAST,
+                ACHIEVEMENT_FLAWLESS_EXECUTION,
+                ACHIEVEMENT_HIGH_ROLLER,
+                ACHIEVEMENT_MAXIMUM_OVERKILL,
+                ACHIEVEMENT_CRUNCHING_NUMBERS,
+        };
+}
+
+std::vector<achievement_e> magic_event_achievement_cases() {
+        return {
+                ACHIEVEMENT_ANCIENT_SECRETS,
+                ACHIEVEMENT_FRIENDLY_FIRE,
+                ACHIEVEMENT_QUENCHING_THE_FLAME,
+                ACHIEVEMENT_CONDUCTIVE_CRITTERS,
+                ACHIEVEMENT_BRAINS_BEATS_BRAWN,
+                ACHIEVEMENT_METEORIC_RISE,
+                ACHIEVEMENT_GRAVE_MISTAKE,
+                ACHIEVEMENT_SECOND_LIFE,
+                ACHIEVEMENT_CREATIVE_CASTER,
+                ACHIEVEMENT_WATCH_THE_WORLD_BURN,
+                ACHIEVEMENT_TURTLING_UP,
+                ACHIEVEMENT_MASTER_OF_THE_ARCANE,
+                ACHIEVEMENT_ENERGIZER_BUNNY,
+        };
+}
+
+void initialize_combat_achievement_game(game_t& game, hero_t& attacker, player_t& player) {
+        player.player_number = PLAYER_1;
+        player.is_human = true;
+        game.players.push_back(player);
+        attacker.player = PLAYER_1;
+        game.battle.attacking_hero = &attacker;
+        game.battle.result = BATTLE_BOTH_LOSE;
+        game.battle.fn_emit_combat_action = [](const battle_action_t&) {};
+        game.remove_hero_callback_fn = [](hero_t*, bool) {};
+        game.remove_interactable_object_callback_fn = [](interactable_object_t*, bool) {};
+        game.show_dialog_callback_fn = [](dialog_type_e, interactable_object_t*, hero_t*, int, int) {};
+        game.show_hero_levelup_callback_fn = [](hero_t*, skill_e, skill_e, skill_e, stat_e, bool) {};
+        game.game_event_callback_fn = [](game_state_update_e, player_e, int) {};
+        game.update_interactable_object_callback_fn = [](interactable_object_t*) {};
+}
+
+void apply_magic_event_condition(game_t& game, hero_t& attacker, achievement_e achievement) {
+        switch(achievement) {
+                case ACHIEVEMENT_FRIENDLY_FIRE:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        game.battle.attacker_stats.friendly_fire_spell_hits = 1;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_QUENCHING_THE_FLAME:
+                        game.battle.attacker_stats.frost_kill_fire_immune = 1;
+                        break;
+                case ACHIEVEMENT_CONDUCTIVE_CRITTERS:
+                        game.battle.attacker_stats.chain_lightning_5kills = 1;
+                        break;
+                case ACHIEVEMENT_BRAINS_BEATS_BRAWN:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        game.battle.attacker_stats.total_spell_damage_done = 1;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_METEORIC_RISE:
+                        game.battle.attacker_stats.meteor_shower_75kills = 1;
+                        break;
+                case ACHIEVEMENT_GRAVE_MISTAKE:
+                        game.battle.attacker_stats.implosion_finish_necromancer = 1;
+                        break;
+                case ACHIEVEMENT_SECOND_LIFE:
+                        game.battle.attacker_stats.resurrection_1000hp = 1;
+                        break;
+                case ACHIEVEMENT_CREATIVE_CASTER:
+                        game.battle.attacker_stats.unique_spells_cast = 6;
+                        break;
+                case ACHIEVEMENT_WATCH_THE_WORLD_BURN:
+                        game.battle.attacker_stats.armageddon_5000_damage = 1;
+                        break;
+                case ACHIEVEMENT_TURTLING_UP:
+                        game.update_achievement_stats(game.get_player(PLAYER_1).player_stats.achievement_event_counts[achievement], 1, achievement);
+                        break;
+                case ACHIEVEMENT_MASTER_OF_THE_ARCANE:
+                        game.battle.attacker_stats.total_spells_cast_nature = 1;
+                        game.battle.attacker_stats.total_spells_cast_arcane = 1;
+                        game.battle.attacker_stats.total_spells_cast_holy = 1;
+                        game.battle.attacker_stats.total_spells_cast_destruction = 1;
+                        game.battle.attacker_stats.total_spells_cast_death = 1;
+                        break;
+                case ACHIEVEMENT_ENERGIZER_BUNNY:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        attacker.knowledge = 1;
+                        attacker.mana = attacker.get_maximum_mana() * 2;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                default:
+                        break;
+        }
+}
+
+void apply_might_event_condition(game_t& game, hero_t& attacker, hero_t& defender, achievement_e achievement) {
+        switch(achievement) {
+                case ACHIEVEMENT_MAXED_OUT:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        attacker.attack = 99;
+                        attacker.defense = 99;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_GLASS_CANNON:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        attacker.attack = 25;
+                        attacker.defense = 0;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_IMMOVABLE_OBJECT:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        attacker.attack = 0;
+                        attacker.defense = 25;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_OVERMATCHED:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        defender.player = PLAYER_NONE;
+                        game.battle.defending_hero = &defender;
+                        attacker.attack = 10;
+                        attacker.defense = 10;
+                        defender.attack = 1;
+                        defender.defense = 1;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_EQUAL_GROUNDS:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        defender.player = PLAYER_NONE;
+                        game.battle.defending_hero = &defender;
+                        attacker.attack = 5;
+                        attacker.defense = 5;
+                        defender.attack = 5;
+                        defender.defense = 5;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_MASSACRE:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.total_units_killed = 1;
+                        game.battle.attacker_stats.total_units_killed = 1000;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_TITANIC_SMACKDOWN:
+                        game.battle.attacker_stats.titanic_smackdowns = 1;
+                        break;
+                case ACHIEVEMENT_THE_BIGGER_THEY_ARE:
+                        game.battle.attacker_stats.tier6_killed_by_tier1_army = 1;
+                        break;
+                case ACHIEVEMENT_UNBREAKABLE:
+                        game.get_player(PLAYER_1).player_stats.achievement_event_counts[ACHIEVEMENT_FLAWLESS_EXECUTION] = 1;
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        game.battle.attacker_stats.total_attacks_received = 10;
+                        break;
+                case ACHIEVEMENT_OUTLAST:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        game.battle.round = 20;
+                        game.battle.attacker_stats.total_units_lost = 1;
+                        break;
+                case ACHIEVEMENT_FLAWLESS_EXECUTION:
+                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                        break;
+                case ACHIEVEMENT_HIGH_ROLLER:
+                        game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.total_critical_hits = 1;
+                        game.battle.attacker_stats.total_attacks_made = 1;
+                        game.battle.attacker_stats.total_critical_hits = 1;
+                        break;
+                case ACHIEVEMENT_MAXIMUM_OVERKILL:
+                        game.battle.attacker_stats.maximum_overkill_hits = 1;
+                        break;
+                case ACHIEVEMENT_CRUNCHING_NUMBERS:
+                        game.battle.attacker_stats.exact_melee_kills = 1;
+                        break;
+                default:
+                        break;
+        }
+}
+
+void test_storm_drinker_lightning_spell_damage_cast_progress_and_callback() {
+        game_t game;
+        hero_t attacker;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker, player);
+
+        attacker.power = 200;
+        attacker.mana = 1000;
+        attacker.spellbook.push_back(SPELL_LIGHTNING_BOLT);
+
+        auto& target = game.battle.defending_army.troops[0];
+        target = make_battlefield_unit(UNIT_SKELETON, 1000, false, 1, 8, 5);
+        place_battlefield_unit(game.battle, target);
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) {
+                earned.push_back(achievement);
+        };
+
+        const auto first_threshold = first_threshold_or_one(game_config::get_achievement(ACHIEVEMENT_STORM_DRINKER));
+        auto& progress = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.lightning_spell_damage;
+        progress = first_threshold - 1;
+
+        expect_true(game.battle.cast_spell(&attacker, SPELL_LIGHTNING_BOLT, target.x, target.y, &target) == SPELL_RESULT_OK,
+                    "Lightning Bolt should successfully hit the enemy stack in the Storm Drinker scenario");
+        expect_true(game.battle.attacker_stats.lightning_spell_damage > 0,
+                    "Lightning Bolt should record lightning spell damage for the attacking hero");
+
+        const auto lightning_damage = game.battle.attacker_stats.lightning_spell_damage;
+        game.accept_battle_results();
+
+        expect_eq(progress, first_threshold - 1 + lightning_damage,
+                  "Storm Drinker should add actual Lightning Bolt damage to cumulative lightning spell damage");
+        expect_eq(earned_count(earned, ACHIEVEMENT_STORM_DRINKER), size_t(1),
+                  "Storm Drinker callback should fire exactly once after Lightning Bolt crosses the first tier threshold");
+        expect_true(!earned.empty(),
+                    "Lightning Bolt scenario should fire at least the Storm Drinker achievement callback");
+}
+
+template<typename TestCase>
+void test_magic_combat_stat_case(const TestCase& test_case) {
+        game_t game;
+        hero_t attacker;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker, player);
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) {
+                earned.push_back(achievement);
+        };
+
+        const auto first_threshold = first_threshold_or_one(game_config::get_achievement(test_case.achievement));
+        auto& progress = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.*(test_case.stat);
+        progress = first_threshold - 1;
+
+        game.battle.attacker_stats.*(test_case.stat) = 1;
+        game.accept_battle_results();
+
+        expect_eq(progress, first_threshold,
+                  game_config::get_achievement(test_case.achievement).name + " should increment cumulative magic combat stat exactly");
+        expect_eq(earned_count(earned, test_case.achievement), size_t(1),
+                  game_config::get_achievement(test_case.achievement).name + " callback should fire exactly once when crossing the first tier threshold");
+        expect_eq(earned.size(), size_t(1),
+                  game_config::get_achievement(test_case.achievement).name + " should be the only achievement callback in this combat scenario");
+}
+
+void test_magic_combat_stat_progress_and_callbacks() {
+        for(const auto& test_case : small_magic_combat_stat_achievement_cases())
+                test_magic_combat_stat_case(test_case);
+        for(const auto& test_case : magic_combat_stat_achievement_cases()) {
+                test_magic_combat_stat_case(test_case);
+        }
+}
+
+void test_magic_event_progress_and_callbacks() {
+        for(const auto achievement : magic_event_achievement_cases()) {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e earned_achievement) {
+                        earned.push_back(earned_achievement);
+                };
+
+                const auto first_threshold = first_threshold_or_one(game_config::get_achievement(achievement));
+                auto& progress = game.get_player(PLAYER_1).player_stats.achievement_event_counts[achievement];
+                progress = first_threshold - 1;
+
+                if(achievement == ACHIEVEMENT_ANCIENT_SECRETS)
+                        game.update_achievement_stats(progress, 1, achievement);
+                else {
+                        apply_magic_event_condition(game, attacker, achievement);
+                        game.accept_battle_results();
+                }
+
+                expect_eq(progress, first_threshold,
+                          game_config::get_achievement(achievement).name + " should increment magic event progress exactly");
+                expect_eq(earned_count(earned, achievement), size_t(1),
+                          game_config::get_achievement(achievement).name + " callback should fire exactly once when crossing the first tier threshold");
+                expect_eq(earned.size(), size_t(1),
+                          game_config::get_achievement(achievement).name + " should be the only achievement callback in this magic event scenario");
+        }
+}
+
+void test_all_magic_achievements_have_specific_test_case() {
+        std::set<achievement_e> covered;
+        for(const auto& test_case : small_magic_combat_stat_achievement_cases())
+                covered.insert(test_case.achievement);
+        for(const auto& test_case : magic_combat_stat_achievement_cases())
+                covered.insert(test_case.achievement);
+        for(const auto achievement : magic_event_achievement_cases())
+                covered.insert(achievement);
+
+        for(const auto& achievement : game_config::get_achievements()) {
+                if(achievement.type != ACHIEVEMENT_TYPE_MAGIC)
+                        continue;
+
+                expect_true(covered.count(achievement.id) == 1, achievement.name + " should have an explicit magic achievement test case");
+        }
+}
+
+
+template<typename TestCase>
+void test_might_combat_stat_case(const TestCase& test_case) {
+        game_t game;
+        hero_t attacker;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker, player);
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) {
+                earned.push_back(achievement);
+        };
+
+        const auto first_threshold = first_threshold_or_one(game_config::get_achievement(test_case.achievement));
+        auto& progress = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.*(test_case.stat);
+        progress = first_threshold - 1;
+
+        game.battle.attacker_stats.*(test_case.stat) = 1;
+        game.accept_battle_results();
+
+        expect_eq(progress, first_threshold,
+                  game_config::get_achievement(test_case.achievement).name + " should increment cumulative might combat stat exactly");
+        expect_eq(earned_count(earned, test_case.achievement), size_t(1),
+                  game_config::get_achievement(test_case.achievement).name + " callback should fire exactly once when crossing the first tier threshold");
+        expect_eq(earned.size(), size_t(1),
+                  game_config::get_achievement(test_case.achievement).name + " should be the only achievement callback in this might combat scenario");
+}
+
+void test_might_combat_stat_progress_and_callbacks() {
+        for(const auto& test_case : small_might_combat_stat_achievement_cases())
+                test_might_combat_stat_case(test_case);
+        for(const auto& test_case : might_combat_stat_achievement_cases())
+                test_might_combat_stat_case(test_case);
+}
+
+void test_might_event_progress_and_callbacks() {
+        for(const auto achievement : might_event_achievement_cases()) {
+                game_t game;
+                hero_t attacker;
+                hero_t defender;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e earned_achievement) {
+                        earned.push_back(earned_achievement);
+                };
+
+                const auto first_threshold = first_threshold_or_one(game_config::get_achievement(achievement));
+                auto& progress = game.get_player(PLAYER_1).player_stats.achievement_event_counts[achievement];
+                progress = first_threshold - 1;
+
+                apply_might_event_condition(game, attacker, defender, achievement);
+                game.accept_battle_results();
+
+                expect_eq(progress, first_threshold,
+                          game_config::get_achievement(achievement).name + " should increment might event progress exactly");
+                expect_eq(earned_count(earned, achievement), size_t(1),
+                          game_config::get_achievement(achievement).name + " callback should fire exactly once when crossing the first tier threshold");
+                expect_eq(earned.size(), size_t(1),
+                          game_config::get_achievement(achievement).name + " should be the only achievement callback in this might event scenario");
+        }
+}
+
+void test_all_might_achievements_have_specific_test_case() {
+        std::set<achievement_e> covered;
+        for(const auto& test_case : small_might_combat_stat_achievement_cases())
+                covered.insert(test_case.achievement);
+        for(const auto& test_case : might_combat_stat_achievement_cases())
+                covered.insert(test_case.achievement);
+        for(const auto achievement : might_event_achievement_cases())
+                covered.insert(achievement);
+
+        for(const auto& achievement : game_config::get_achievements()) {
+                if(achievement.type != ACHIEVEMENT_TYPE_MIGHT)
+                        continue;
+
+                expect_true(covered.count(achievement.id) == 1, achievement.name + " should have an explicit might achievement test case");
+        }
+}
+
+} // namespace
+
+int run_combat_achievement_tests() {
+        failures = 0;
+        test_storm_drinker_lightning_spell_damage_cast_progress_and_callback();
+        test_magic_combat_stat_progress_and_callbacks();
+        test_magic_event_progress_and_callbacks();
+        test_all_magic_achievements_have_specific_test_case();
+        test_might_combat_stat_progress_and_callbacks();
+        test_might_event_progress_and_callbacks();
+        test_all_might_achievements_have_specific_test_case();
+        return failures;
+}


### PR DESCRIPTION
### Motivation
- Add comprehensive automated tests for combat-related achievements (Magic and Might) and integrate them into the existing achievement test runner to improve coverage and catch regressions.
- Provide a concrete battlefield scenario for at least one spell-based achievement (Storm Drinker) and validate that achievement config and progress mechanics work with battle results.

### Description
- Add `tests/combat_achievement_tests.cpp` implementing Magic and Might achievement test cases, helper routines to construct battlefield scenarios, and `run_combat_achievement_tests()` to execute the suite.
- Update `tests/achievement_tests.cpp` to declare and call `run_combat_achievement_tests()`, ensure `spells` config is loaded via `game_config::load_spells("../")`, and add minimal callback stubs required by combat tests.
- Update `tests/achievement_tests.pro` to include `combat_achievement_tests.cpp` in the test binary build.
- Add `achievements_tests_progress.txt` documenting current coverage, passing state, and remaining work to flesh out concrete combat scenarios for additional achievements.

### Testing
- Built and ran the full achievement test suite locally with `qmake tests/achievement_tests.pro -o /tmp/achievement_tests.Makefile && make -f /tmp/achievement_tests.Makefile -j2` and executed the test binary with `(cd tests && ../achievement_tests)`, and the run succeeded with all achievement tests passing.
- The new combat achievement tests were executed via the integrated `run_combat_achievement_tests()` call and reported no failures in the local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c0ff54180832da3f0d5358293e0c8)