### PR TITLE
Fix Fortitude HP after buff expiration

### DIFF
--- a/game/src/core/battlefield.cpp
+++ b/game/src/core/battlefield.cpp
@@ -973,6 +973,16 @@ uint battlefield_t::get_unit_adjusted_hp(const battlefield_unit_t& unit) {
 	return hp;
 }
 
+void battlefield_t::adjust_unit_health_after_max_hp_change(battlefield_unit_t& unit, uint previous_max_hp) {
+	if(unit.stack_size == 0)
+		return;
+
+	previous_max_hp = std::max(1u, previous_max_hp);
+	const uint new_max_hp = get_unit_adjusted_hp(unit);
+	const float hp_percent = unit.unit_health / static_cast<float>(previous_max_hp);
+	unit.unit_health = std::clamp(static_cast<uint>(new_max_hp * hp_percent), 1u, new_max_hp);
+}
+
 std::pair<uint, uint> battlefield_t::get_unit_adjusted_damage_range(battlefield_unit_t& unit) {
 	auto& army_of_unit = unit.is_attacker ? attacking_army : defending_army;
 	
@@ -1919,9 +1929,7 @@ spell_result_e battlefield_t::cast_spell(hero_t* caster, spell_e spell_id, int t
 				return SPELL_RESULT_INVALID_TARGET;
 
 			auto buff = get_buff_for_spell(spell_id);
-			float prebuff_hp_percent = 1.f;
-			if(buff == BUFF_INCREASED_HEALTH) //adjust hp to match the previous percentage
-				prebuff_hp_percent = target->unit_health / (float)get_unit_adjusted_hp(*target);
+			const uint previous_max_hp = get_unit_adjusted_hp(*target);
 			
 			auto magnitude = spell.multiplier[0].get_value(caster->get_effective_power(), caster->get_spell_effect_multiplier(spell_id));
 			auto duration = spell.multiplier[1].get_value(caster->get_effective_power(), caster->get_spell_effect_multiplier(spell_id));
@@ -1946,7 +1954,7 @@ spell_result_e battlefield_t::cast_spell(hero_t* caster, spell_e spell_id, int t
 			}
 
 			if(buff == BUFF_INCREASED_HEALTH)
-				target->unit_health = std::clamp((uint)(get_unit_adjusted_hp(*target) * prebuff_hp_percent), 1u, get_unit_adjusted_hp(*target));
+				adjust_unit_health_after_max_hp_change(*target, previous_max_hp);
 
 			if(buff == BUFF_CATS_SWIFTNESS)
 				target->retaliations_remaining += target->get_buff(BUFF_CATS_SWIFTNESS).magnitude;
@@ -1974,9 +1982,12 @@ spell_result_e battlefield_t::cast_spell(hero_t* caster, spell_e spell_id, int t
 					continue;
 				
 				auto buff = get_buff_for_spell(spell_id);
+				const uint previous_max_hp = get_unit_adjusted_hp(unit);
 				unit.add_buff(buff, caster->get_effective_power(),
 							 spell.multiplier[0].get_value(caster->get_effective_power(),
 							 caster->get_spell_effect_multiplier(spell_id)));
+				if(buff == BUFF_INCREASED_HEALTH)
+					adjust_unit_health_after_max_hp_change(unit, previous_max_hp);
 
 				if(caster->has_talent(TALENT_INNERVATE)) {
 					unit.add_buff(BUFF_INCREASED_INITIATIVE, 2);
@@ -2952,14 +2963,18 @@ void battlefield_t::next_round() {
 				buff.duration--;
 			
 			if(buff.duration == 0) {
+				const auto expired_buff_id = buff.buff_id;
+				const uint previous_max_hp = get_unit_adjusted_hp(unit);
 				if(!is_quick_combat) {
 					battle_action_t action; //todo: group these up?
 					action.action = ACTION_BUFF_EXPIRED;
 					action.acting_unit = unit;
-					action.buff_id = buff.buff_id;
+					action.buff_id = expired_buff_id;
 					fn_emit_combat_action(action);
 				}
-				unit.remove_buff(buff.buff_id);
+				unit.remove_buff(expired_buff_id);
+				if(expired_buff_id == BUFF_INCREASED_HEALTH)
+					adjust_unit_health_after_max_hp_change(unit, previous_max_hp);
 			}
 		}
 

--- a/game/src/core/battlefield.h
+++ b/game/src/core/battlefield.h
@@ -484,6 +484,7 @@ struct battlefield_t {
 	uint get_unit_adjusted_attack(battlefield_unit_t& unit);
 	uint get_unit_adjusted_defense(battlefield_unit_t& unit);
 	uint get_unit_adjusted_hp(const battlefield_unit_t& unit);
+	void adjust_unit_health_after_max_hp_change(battlefield_unit_t& unit, uint previous_max_hp);
 	std::pair<uint, uint> get_unit_adjusted_damage_range(battlefield_unit_t& unit);
 
 	int get_hero_adjusted_power(hero_t* hero);

--- a/tests/combat_core_tests.cpp
+++ b/tests/combat_core_tests.cpp
@@ -216,6 +216,32 @@ void test_healing_exact_edge_cases_from_regression_suite() {
         expect_eq(result.second, static_cast<uint16_t>(0), "healing a full stack should report no revived units");
 }
 
+void test_fortitude_expiration_preserves_health_percentage() {
+        battlefield_t battlefield;
+        battlefield.fn_emit_combat_action = [](const battle_action_t&) {};
+        auto& full_unit = battlefield.attacking_army.troops[0];
+        full_unit = make_unit(UNIT_HIPPOGRIFF, 2, true, 4, 4, 4);
+        full_unit.unit_health = full_unit.get_base_max_hitpoints();
+        expect_true(full_unit.add_buff(BUFF_INCREASED_HEALTH, 1, 50), "test setup should fortify full unit");
+        battlefield.adjust_unit_health_after_max_hp_change(full_unit, full_unit.get_base_max_hitpoints());
+        expect_eq(battlefield.get_unit_adjusted_hp(full_unit), static_cast<uint>(60), "fortitude should increase Hippogriff max HP by 50%");
+        expect_eq(full_unit.unit_health, static_cast<uint16_t>(60), "full fortified unit should be full at adjusted max HP");
+
+        auto& damaged_unit = battlefield.defending_army.troops[0];
+        damaged_unit = make_unit(UNIT_HIPPOGRIFF, 2, false, 5, 6, 4);
+        damaged_unit.unit_health = 20;
+        expect_true(damaged_unit.add_buff(BUFF_INCREASED_HEALTH, 1, 50), "test setup should fortify damaged unit");
+        battlefield.adjust_unit_health_after_max_hp_change(damaged_unit, damaged_unit.get_base_max_hitpoints());
+        expect_eq(damaged_unit.unit_health, static_cast<uint16_t>(30), "damaged fortified unit should keep its health percentage when max HP rises");
+
+        battlefield.next_round();
+
+        expect_true(!full_unit.has_buff(BUFF_INCREASED_HEALTH), "fortitude should expire after its duration reaches zero");
+        expect_eq(battlefield.get_unit_adjusted_hp(full_unit), static_cast<uint>(40), "expired fortitude should restore base max HP");
+        expect_eq(full_unit.unit_health, static_cast<uint16_t>(40), "full unit HP should be capped when fortitude expires");
+        expect_eq(damaged_unit.unit_health, static_cast<uint16_t>(20), "damaged unit should keep its health percentage when fortitude expires");
+}
+
 void test_damage_prediction_and_adjusted_stats_are_bounded() {
         battlefield_t battlefield;
         battlefield.fn_emit_combat_action = [](const battle_action_t&) {};
@@ -385,6 +411,7 @@ int main() {
         test_healing_simulate_and_resurrect();
         test_dead_stack_zero_healing_does_not_reoccupy_hex();
         test_healing_exact_edge_cases_from_regression_suite();
+        test_fortitude_expiration_preserves_health_percentage();
         test_damage_prediction_and_adjusted_stats_are_bounded();
         test_turn_queue_orders_by_adjusted_initiative_speed_and_troop_bar();
         test_wait_queue_uses_adjusted_reverse_order();


### PR DESCRIPTION
### Motivation
- Fortitude (`BUFF_INCREASED_HEALTH`) could change a unit's max HP without adjusting `unit.unit_health`, allowing units to end up with HP greater than their new max when the buff expired.
- The fix ensures a unit's top-unit HP remains at the same percentage of max HP when max HP changes and is clamped when the buff is removed.

### Description
- Add `adjust_unit_health_after_max_hp_change(battlefield_unit_t&, uint)` in `game/src/core/battlefield.*` to recompute and clamp `unit.unit_health` based on the previous max HP percentage.
- Use the helper when applying single-target fortify effects (`cast_spell` path) by recording `previous_max_hp` and calling `adjust_unit_health_after_max_hp_change` after adding the buff.
- Apply the same helper for mass-buff application paths so every unit preserves its HP percentage when fortitude is applied.
- On buff expiration inside `next_round()` record the `previous_max_hp` before removal and call the helper after removing `BUFF_INCREASED_HEALTH` so `unit.unit_health` is reduced to the restored max if necessary.
- Add a regression test `test_fortitude_expiration_preserves_health_percentage()` in `tests/combat_core_tests.cpp` that covers both full-health and damaged units through fortify application and expiry.

### Testing
- Built and ran the combat test binary with `qmake tests/combat_core_tests.pro && make && ./combat_core_tests`.
- All combat core tests, including the new `test_fortitude_expiration_preserves_health_percentage`, passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fbc5224a4832da3a2a81034bcecbe)