### PR TITLE
Code cleanup: fix unused params, tighten bounds and index types, add default cases, and minor bug fixes

### DIFF
--- a/game/src/core/adventure_map.cpp
+++ b/game/src/core/adventure_map.cpp
@@ -171,9 +171,8 @@ terrain_type_e get_faction_native_terrain(hero_class_e faction) {
 		case HERO_CLASS_SORCERESS: return TERRAIN_GRASS;
 		case HERO_CLASS_WARLOCK: return TERRAIN_LAVA;
 		case HERO_CLASS_WIZARD: return TERRAIN_SNOW;
+		default: return TERRAIN_UNKNOWN;
 	}
-	
-	return TERRAIN_UNKNOWN;
 }
 
 hero_class_e get_faction_from_native_terrain_type(terrain_type_e terrain_type) {
@@ -633,13 +632,13 @@ bool adventure_map_t::remove_interactable_object(interactable_object_t* object) 
 
 const map_tile_t& adventure_map_t::get_tile(int x, int y) const {
 	assert(x >= 0 && x < width && y >= 0 && y < height);
-	assert(y * width + x < tiles.size());
+	assert(y * width + x < std::ssize(tiles));
 	return tiles[y * width + x];
 }
 
 map_tile_t& adventure_map_t::get_tile(int x, int y) {
 	assert(x >= 0 && x < width && y >= 0 && y < height);
-	assert(y * width + x < tiles.size());
+	assert(y * width + x < std::ssize(tiles));
 	return tiles[y * width + x];
 }
 
@@ -944,7 +943,7 @@ route_t adventure_map_t::get_route(const hero_t* hero, int x2, int y2, const gam
 	return route;
 }
 
-route_t adventure_map_t::get_route_ignoring_blockables(const hero_t* hero, int x2, int y2, const game_t* game) const {
+route_t adventure_map_t::get_route_ignoring_blockables(const hero_t* hero, int x2, int y2, const game_t*) const {
 	route_t route;
 	if(!hero || !tile_valid(x2, y2))
 		return route;
@@ -1187,7 +1186,7 @@ interactable_object_t* adventure_map_t::get_interactable_object_for_tile(int x, 
 		return nullptr;
 	
 	auto ind = get_tile(x, y).interactable_object - 1;
-	if(ind >= objects.size())
+	if(ind >= std::ssize(objects))
 		return nullptr;
 
 	return objects[ind];
@@ -1205,7 +1204,7 @@ extern const char* tr(const char*);
 //Swarm = 250-499
 //Zounds = 500-999
 //Legion = 1000+
-std::pair<std::string, std::string> adventure_map_t::get_troop_count_strings(uint troop_count, uint scouting_level, bool use_prefix) const {
+std::pair<std::string, std::string> adventure_map_t::get_troop_count_strings(uint troop_count, uint, bool use_prefix) const {
 	QString text = "???";
 	std::string count = "?";
 	uint min = 0;
@@ -1338,6 +1337,7 @@ map_action_e adventure_map_t::move_hero_to_tile(hero_t& hero, int x, int y, game
 			case TERRAIN_SNOW: game.update_achievement_stats(game.get_player(hero.player).player_stats.movement.total_hero_steps_taken_on_snow, 1, ACHIEVEMENT_COLD_AS_ICE); break;
 			case TERRAIN_SWAMP: game.update_achievement_stats(game.get_player(hero.player).player_stats.movement.total_hero_steps_taken_on_swamp, 1, ACHIEVEMENT_WELCOME_TO_THE_JUNGLE); break;
 			case TERRAIN_JUNGLE: game.update_achievement_stats(game.get_player(hero.player).player_stats.movement.total_hero_steps_taken_on_jungle, 1, ACHIEVEMENT_WELCOME_TO_THE_JUNGLE); break;
+			default: break;
 		}
 	}
 
@@ -1466,14 +1466,14 @@ bool adventure_map_t::move_all_artifacts_from_hero_to_hero(hero_t* hero_from, he
 		return false;
 
 	if(!backpack_only) {
-		for(int i = 0; i < hero_from->artifacts.size(); i++) {
+		for(std::size_t i = 0; i < hero_from->artifacts.size(); i++) {
 			if(hero_to->pickup_artifact(hero_from->artifacts[i]))
 				hero_from->artifacts[i] = ARTIFACT_NONE;
 		}
 	}
 
 	if(include_backpack) {
-		for(int i = 0; i < hero_from->backpack.size(); i++) {
+		for(std::size_t i = 0; i < hero_from->backpack.size(); i++) {
 			if(hero_to->pickup_artifact(hero_from->backpack[i]))
 				hero_from->backpack[i] = ARTIFACT_NONE;
 		}
@@ -1611,7 +1611,7 @@ int adventure_map_t::get_next_open_troop_slot(const troop_group_t& troops) {
 }
 
 bool adventure_map_t::dismiss_troops(hero_t* hero, int troop_index) {
-	if(!hero || troop_index < 0 || troop_index >= game_config::HERO_TROOP_SLOTS)
+	if(!hero || troop_index < 0 || troop_index >= static_cast<int>(game_config::HERO_TROOP_SLOTS))
 		return false;
 
 	hero->troops[troop_index].clear();
@@ -1619,7 +1619,7 @@ bool adventure_map_t::dismiss_troops(hero_t* hero, int troop_index) {
 }
 
 bool adventure_map_t::dismiss_troops(town_t* town, int troop_index) {
-	if(!town || troop_index < 0 || troop_index >= game_config::HERO_TROOP_SLOTS)
+	if(!town || troop_index < 0 || troop_index >= static_cast<int>(game_config::HERO_TROOP_SLOTS))
 		return false;
 
 	town->garrison_troops[troop_index].clear();
@@ -2301,7 +2301,7 @@ bool adventure_map_t::is_route_passable(hero_t* hero, int x2, int y2, game_t* ga
 	return route.size() != 0;
 }
 
-int adventure_map_t::get_time_to_tile(const hero_t* hero, int x, int y, game_t* game) const {
+int adventure_map_t::get_time_to_tile(const hero_t* hero, int, int, game_t*) const {
 	if(!hero)
 		return -1;
 

--- a/game/src/core/ai_adventure_map.cpp
+++ b/game/src/core/ai_adventure_map.cpp
@@ -265,7 +265,6 @@ struct hero_plan_t {
 
 
 interactable_object_t* find_best_object(const hero_t& hero, const adventure_map_t& map, const game_t& game) {
-	interactable_object_t* valuable_object = nullptr;
 	//find the highest value object in a NxN radius
 	int radius = 7;
 	interactable_object_t* valuable_obj = nullptr;
@@ -291,14 +290,11 @@ interactable_object_t* find_best_object(const hero_t& hero, const adventure_map_
 	return valuable_obj;
 }
 
-bool game_t::ai_should_recruit_troops(const hero_t* hero, const town_t* town) const {
+bool game_t::ai_should_recruit_troops(const hero_t*, const town_t* town) const {
 	if(!town)
 		return false;
 
-	auto player = hero ? hero->player : town->player;
-
 	bool should_buy = false;
-	int slot = 0;
 	for(auto& tr : town->available_troops) {
 		int afford_count = tr.stack_size;
 		if(afford_count)
@@ -396,6 +392,8 @@ bool game_t::ai_pickup_object(hero_t* hero, interactable_object_t* object) {
 
 			break;
 		}
+		default:
+			break;
 	}
 
 	if(picked_up_item) {
@@ -433,7 +431,6 @@ bool game_t::ai_move_hero_to_object(hero_t* hero, interactable_object_t* object)
 				
 			last_turn_actions[player_num].push_back(movement_action);
 			map.move_hero_to_tile(*hero, step->tile.x, step->tile.y, *this);
-			auto obj = map.get_interactable_object_for_tile(step->tile.x, step->tile.y);
 			//map.interact_with_object(&hero, obj, *this);
 		}
 	}

--- a/game/src/core/battlefield.cpp
+++ b/game/src/core/battlefield.cpp
@@ -227,7 +227,7 @@ QDataStream& operator>>(QDataStream& stream, battlefield_t& battlefield) {
 	return stream;
 }
 
-bool write_battlefield_to_stream(QDataStream& stream, const battlefield_t& battlefield, const game_t& game) {
+bool write_battlefield_to_stream(QDataStream& stream, const battlefield_t& battlefield, const game_t&) {
 	stream << battlefield;
 
 	//write pointers as ids
@@ -280,6 +280,8 @@ const std::string stringify_combat_action(const battle_action_t& action, const s
 	QString unit_name = tr(action.acting_unit.get_unit_name().c_str(), count);
 
 	switch(action.action) {
+		default:
+			break;
 		case ACTION_ROUND_ENDED: {
 			message = tr("End of round %1.", count)
 				.arg(action.effect_value);
@@ -447,7 +449,6 @@ const std::string stringify_combat_action(const battle_action_t& action, const s
 		
 		case ACTION_UNIT_LIFESTEAL: {
 			auto life_stolen = action.affected_units.front().damage;
-			auto units_revived = action.affected_units.front().kills;
 			message = tr("The %1 %2 %3 life.", count)
 				.arg(unit_name)
 				.arg(tr("steals", count))
@@ -585,8 +586,8 @@ std::set<battlefield_hex_t*> battlefield_t::get_movement_range(battlefield_unit_
 
 	//temporary fix for two-hex units
 	if(unit.is_two_hex()) {
-		for(int y = 0; y < game_config::BATTLEFIELD_HEIGHT; y++) {
-			for(int x = 0; x < game_config::BATTLEFIELD_WIDTH; x++) {
+		for(uint y = 0; y < game_config::BATTLEFIELD_HEIGHT; y++) {
+			for(uint x = 0; x < game_config::BATTLEFIELD_WIDTH; x++) {
 				if(!is_move_valid(unit, x, y))
 					continue;
 
@@ -678,7 +679,7 @@ bool battlefield_t::is_move_valid(battlefield_unit_t &unit, uint target_x, uint 
 		return false;
 
 	//only calculate route if unit is moving to a different hex than it currently occupies
-	if(unit.x == effective_target_x && unit.y == target_y)
+	if(unit.x == static_cast<int>(effective_target_x) && unit.y == static_cast<int>(target_y))
 		return true;
 
 	//if the target hex is occupied by a unit that isn't the acting unit, bail out
@@ -702,7 +703,7 @@ bool battlefield_t::is_move_valid(battlefield_unit_t &unit, uint target_x, uint 
 	if(route.size() == 0)
 		return false;
 	
-	if(route.size() > get_unit_adjusted_speed(unit))
+	if(std::ssize(route) > get_unit_adjusted_speed(unit))
 		return false;
 	
 	return true;
@@ -1398,7 +1399,7 @@ std::vector<battlefield_unit_t*> battlefield_t::get_chain_lightning_targets(batt
 
 	int max_target_count = jump_count + 1;
 
-	while(targets.size() < max_target_count) {
+	while(std::ssize(targets) < max_target_count) {
 		battlefield_unit_t* next_target = nullptr;
 		int closest_distance = 255;
 
@@ -1451,7 +1452,7 @@ std::vector<battlefield_unit_t*> battlefield_t::cast_spell_on_random_troops(army
 	std::shuffle(potential_targets.begin(), potential_targets.end(), std::default_random_engine{});
 
 	int picked = 0;
-	while(picked < number_of_troops_affected && picked < potential_targets.size()) {
+	while(picked < number_of_troops_affected && picked < std::ssize(potential_targets)) {
 		auto target = potential_targets[picked++];
 		auto buff = get_buff_for_spell(spell_id);
 		target->add_buff(buff, duration);
@@ -1461,7 +1462,7 @@ std::vector<battlefield_unit_t*> battlefield_t::cast_spell_on_random_troops(army
 	return targets;
 }
 
-spell_result_e battlefield_t::cast_spell(battlefield_unit_t* caster, spell_e spell_id, int target_x, int target_y, battlefield_unit_t* target_unit) {
+spell_result_e battlefield_t::cast_spell(battlefield_unit_t* caster, spell_e spell_id, int, int, battlefield_unit_t* target_unit) {
 	if(!caster || !caster->has_buff(BUFF_SPELLCASTER) || caster->spell_casts_remaining == 0 || caster->has_cast_spell)
 		return SPELL_RESULT_ERROR;
 
@@ -1491,8 +1492,6 @@ spell_result_e battlefield_t::cast_spell(battlefield_unit_t* caster, spell_e spe
 			return SPELL_RESULT_INVALID_TARGET;
 
 		target_unit = targets[std::rand() % targets.size()];
-		target_x = target_unit->x;
-		target_y = target_unit->y;
 	}
 	else if(!is_spell_target_valid(friendly_army.hero, target_unit, spell_id)) {
 		return SPELL_RESULT_INVALID_TARGET;
@@ -2081,7 +2080,7 @@ spell_result_e battlefield_t::cast_spell(hero_t* caster, spell_e spell_id, int t
 			if(!summon_hex)
 				return SPELL_RESULT_INVALID_TARGET;
 
-			int pos = 0;
+			std::size_t pos = 0;
 			for(; pos < caster_troops.size(); pos++) {
 				if(caster_troops[pos].unit_type == UNIT_UNKNOWN)
 					break;
@@ -2562,7 +2561,7 @@ void battlefield_t::reset() {
 	}
 	else if(defending_hero) {
 		int i = 0;
-		for(; i < game_config::HERO_TROOP_SLOTS; i++) {
+		for(; i < static_cast<int>(game_config::HERO_TROOP_SLOTS); i++) {
 			if(defending_hero->troops[i].stack_size == 0) {
 				defending_army.troops[i].clear();
 				continue;
@@ -2686,18 +2685,17 @@ void battlefield_t::start_combat() {
 		if(!hero)
 			return;
 
-		for(int i = 0; i < hero->artifacts.size(); i++) {
+		for(std::size_t i = 0; i < hero->artifacts.size(); i++) {
 			if(hero->artifacts[i] == ARTIFACT_NONE)
 				continue;
 
 			const auto& art_info = game_config::get_artifact(hero->artifacts[i]);
-			for(int n = 0; n < art_info.effects.size(); n++) {
+			for(std::size_t n = 0; n < art_info.effects.size(); n++) {
 				if(art_info.effects[n].type == EFFECT_SPELL_CAST_ON_BATTLE_START) {
 					auto spell_id = art_info.effects[n].property1.spell;
 					const auto& sp_info = game_config::get_spell(spell_id);
 					auto buff = get_buff_for_spell(spell_id);
 					int target_count = art_info.effects[n].magnitude_1;
-					int duration = art_info.effects[n].magnitude_2;
 					bool cast_on_friendly = is_spell_target_friendly(sp_info.target);
 					
 					auto affected_troops = cast_spell_on_random_troops(cast_on_friendly ? friendly_army.troops : enemy_army.troops, spell_id, target_count);
@@ -2738,7 +2736,7 @@ const std::vector<std::vector<battlefield_direction_e>> battlefield_t::obstacle_
 
 const int obstacle_margin = 2;
 bool obstacle_location_valid(int x, int y) {
-	return (x >= obstacle_margin && x < (game_config::BATTLEFIELD_WIDTH - obstacle_margin) && y < game_config::BATTLEFIELD_HEIGHT);
+	return (x >= obstacle_margin && x < static_cast<int>(game_config::BATTLEFIELD_WIDTH) - obstacle_margin && y < static_cast<int>(game_config::BATTLEFIELD_HEIGHT));
 }
 
 void battlefield_t::reset_castle_walls() {
@@ -2778,8 +2776,8 @@ void battlefield_t::reset_castle_walls() {
 
 void battlefield_t::setup_obstacles(bool only_clear) {
 	//clear existing obstacles if they exist
-	for(int y = 0; y < game_config::BATTLEFIELD_HEIGHT; y++)
-		for(int x = 0; x < game_config::BATTLEFIELD_WIDTH; x++)
+	for(uint y = 0; y < game_config::BATTLEFIELD_HEIGHT; y++)
+		for(uint x = 0; x < game_config::BATTLEFIELD_WIDTH; x++)
 			hex_grid.get_hex(x, y)->passable = true;
 	
 
@@ -3131,7 +3129,7 @@ std::pair<battlefield_unit_t*, battlefield_hex_t*> battlefield_t::get_nearest_ta
 			//skip finding route if we are already on the destination hex
 			if(!(acting_unit->x == hex->x && acting_unit->y == hex->y)) {
 				auto route = get_unit_route(*acting_unit, hex->x, hex->y);
-				if(!route.size() || route.size() > get_unit_adjusted_speed(*acting_unit))
+				if(route.empty() || std::ssize(route) > get_unit_adjusted_speed(*acting_unit))
 					continue;
 
 				distance = (int)route.size();
@@ -3191,7 +3189,7 @@ std::pair<battlefield_unit_t*, battlefield_hex_t*> battlefield_t::get_target_in_
 			//skip finding route if we are already on the destination hex
 			if(!(acting_unit->x == hex->x && acting_unit->y == hex->y)) {
 				auto route = get_unit_route(*acting_unit, hex->x, hex->y);
-				if(!route.size() || route.size() > get_unit_adjusted_speed(*acting_unit))
+				if(route.empty() || std::ssize(route) > get_unit_adjusted_speed(*acting_unit))
 					continue;
 			}
 			
@@ -3296,7 +3294,6 @@ bool battlefield_t::auto_move_troop() {
 	if(troop->has_buff(BUFF_BERSERK)) {
 		auto target = get_nearest_target(troop, true);
 		if(target.first) {
-			auto source_hex = hex_grid.get_hex(troop->x, troop->y);
 			auto target_hex = target.second;
 			move_and_attack_unit(*troop, *target.first, target_hex->x, target_hex->y, target.first->x, target.first->y);
 			return true;
@@ -3321,7 +3318,6 @@ bool battlefield_t::auto_move_troop() {
 	auto target = get_target_in_range(troop);
 	//auto route = get_unit_route(<#battlefield_unit_t &unit#>, <#uint target_x#>, <#uint target_y#>)
 	if(target.first) {
-		auto source_hex = hex_grid.get_hex(troop->x, troop->y);
 		auto target_hex = target.second;
 		move_and_attack_unit(*troop, *target.first, target_hex->x, target_hex->y, target.first->x, target.first->y);
 		return true;
@@ -3987,7 +3983,6 @@ int battlefield_t::unit_belongs_to_army(battlefield_unit_t* unit) {
 }
 
 bool battlefield_t::are_units_adjacent(battlefield_unit_t* attacker, battlefield_unit_t* defender) {
-	bool is_adjacent = false;
 	for(int i = 0; i < 6; i++) {
 		auto direction = (battlefield_direction_e)(TOPLEFT + i);
 		auto next_hex = hex_grid.get_adjacent_hex(defender->x, defender->y, direction);
@@ -4025,7 +4020,7 @@ bool battlefield_t::unit_can_attack(battlefield_unit_t* attacker, battlefield_un
 	
 	//if melee attack, is there a path from attacker to defender?
 	if(!can_troop_shoot(attacker)) {
-		if(attacker->x == from_x && attacker->y == from_y)
+		if(attacker->x == static_cast<int>(from_x) && attacker->y == static_cast<int>(from_y))
 			return true;
 		
 		if(!is_move_valid(*attacker, from_x, from_y))
@@ -4156,8 +4151,6 @@ uint16_t battlefield_t::deal_magic_damage_to_stack(uint32_t damage, battlefield_
 }
 
 uint16_t battlefield_t::deal_damage_to_stack(uint32_t damage, battlefield_unit_t& defender, bool is_spell_damage) {
-	auto& army_of_defender = defender.is_attacker ? attacking_army : defending_army;
-
 	auto starting_troop_count = defender.stack_size;
 	int32_t total_hp = (get_unit_adjusted_hp(defender) * (defender.stack_size - 1)) + defender.unit_health;
 	auto remaining_hp = std::max((int32_t)0, total_hp - (int32_t)damage);
@@ -4229,7 +4222,7 @@ uint16_t battlefield_t::deal_damage_to_stack(uint32_t damage, battlefield_unit_t
 	return kills;
 }
 
-void battlefield_t::handle_post_attack_effects(battlefield_unit_t& attacker, battlefield_unit_t& defender, uint32_t damage, uint16_t kills, bool was_melee_attack, bool was_lucky_strike) {
+void battlefield_t::handle_post_attack_effects(battlefield_unit_t& attacker, battlefield_unit_t& defender, uint32_t damage, uint16_t, bool was_melee_attack, bool was_lucky_strike) {
 	auto& army_of_attacker = attacker.is_attacker ? attacking_army : defending_army;
 	auto& army_of_defender = defender.is_attacker ? attacking_army : defending_army;
 	
@@ -4266,7 +4259,6 @@ void battlefield_t::handle_post_attack_effects(battlefield_unit_t& attacker, bat
 			if(attacker.unit_type == UNIT_VAMPIRE && army_of_attacker.hero && army_of_attacker.hero->specialty == SPECIALTY_VAMPIRES)
 				lifesteal_percent += get_skill_value(.2f, .02f, army_of_attacker.hero->level);
 			
-			bool plural = attacker.stack_size > 1;
 			//if we steal any hp, we steal a minimum of 1 hp
 			uint32_t max_lifesteal_hp = std::max(1u, (uint32_t)std::round(lifesteal_percent * damage));
 			auto actual_lifesteal = apply_healing_to_stack(max_lifesteal_hp, attacker, true);
@@ -4868,7 +4860,6 @@ bool battlefield_t::attack_unit(battlefield_unit_t& attacker, battlefield_unit_t
 			battle_action_t action;
 			action.action = ACTION_MORALED;
 			action.acting_unit = attacker;
-			bool plural = attacker.stack_size > 1;
 			fn_emit_combat_action(action);
 		}
 		attacker.has_moraled = true;
@@ -4916,7 +4907,7 @@ battlefield_unit_t* battlefield_t::get_unit_on_hex(hex_location_t point) {
 //this function only returns units that are able to be resurrected/revived
 //fixme: change to wrapper function get_revivable_unit_on_hex(int x, int y) which checks for clearance
 battlefield_unit_t* battlefield_t::get_dead_unit_on_hex(int x, int y) {
-	for(auto i = 0; i < army_t::MAX_BATTLEFIELD_TROOPS; i++) {
+	for(uint i = 0; i < army_t::MAX_BATTLEFIELD_TROOPS; i++) {
 		auto& at = attacking_army.troops[i];
 		auto& dt = defending_army.troops[i];
 
@@ -5026,6 +5017,8 @@ bool battlefield_t::is_spell_target_valid(hero_t* caster, int target_x, int targ
 
 			return is_spell_target_valid(caster, target, spell_id);
 		}
+		default:
+			break;
 
 	}
 
@@ -5170,7 +5163,6 @@ void battlefield_t::calculate_necromancy_results(battle_result_e battle_result) 
 		//the number of potential open army slots (after grouping up any units) and also
 		//the number and type of undead in the army, to determine what to raise
 		std::set<unit_type_e> existing_undead;
-		int potential_open_slots = 0;
 		//for(
 		
 		

--- a/game/src/core/battlefield_hex_grid.h
+++ b/game/src/core/battlefield_hex_grid.h
@@ -225,7 +225,7 @@ struct battlefield_hex_grid_t {
 			if(!is_in_radius_of(x, y, nx, ny, radius))
 				continue;
 
-			if(!include_origin && (nx == x && ny == y))
+			if(!include_origin && (static_cast<int>(nx) == x && static_cast<int>(ny) == y))
 				continue;
 			
 			neighbor_hexes.push_back(&hexes[nx][ny]);

--- a/game/src/core/game.cpp
+++ b/game/src/core/game.cpp
@@ -49,7 +49,7 @@ QDataStream& operator>>(QDataStream& stream, resource_group_t& resource) {
 
 resource_group_t operator+(const resource_group_t& a, const resource_group_t& b) {
 	resource_group_t out = a;
-	for(int i = 0; i < b.values.size(); i++)
+	for(std::size_t i = 0; i < b.values.size(); i++)
 		out.values[i].value += b.values[i].value;
 
 	return out;
@@ -301,7 +301,6 @@ void game_t::check_for_game_status_updates() {
 
 game_status_e game_t::get_scenario_status() {
 	bool human_alive = false;
-	bool human_allies_alive = false;
 	bool cpu_alive = false;
 
 	//todo handle hotseat
@@ -358,7 +357,7 @@ bool game_t::player_valid(player_e player) const {
 	if(player == PLAYER_NONE || player == PLAYER_NEUTRAL)
 		return false;
 		
-	if((player - 1) >= players.size())
+	if(static_cast<std::size_t>(player - 1) >= players.size())
 		return false;
 	
 	return true;
@@ -1125,6 +1124,8 @@ void game_t::accept_battle_results() {
 
 		if(battle.defending_map_object) {
 			switch(battle.defending_map_object->object_type) {
+				default:
+					break;
 				case OBJECT_GRAVEYARD: {
 					//fixme
 					auto graveyard = (graveyard_t*)battle.defending_map_object;
@@ -1213,6 +1214,8 @@ map_action_e game_t::interact_with_object(hero_t* hero, interactable_object_t* o
 					update_backpack_achievement_stats(*this, hero);
 				break;
 			}
+			default:
+				break;
 		}
 
 		show_dialog_callback_fn(DIALOG_TYPE_WAGON_VISIT, object, hero, wagon->reward_type, was_backpack_full);
@@ -1296,7 +1299,6 @@ map_action_e game_t::interact_with_object(hero_t* hero, interactable_object_t* o
 	}
 	else if(object->object_type == OBJECT_WITCH_HUT) {
 		auto hut = (witch_hut_t*)object;
-		const auto& skill = game_config::get_skill(hut->skill);
 		map.set_object_visited_by_player(hut, hero->player);
 
 		if(hero->has_object_been_visited(map.get_object_id(object))) { //hero has already taken a skill/upgrade from this hut
@@ -1735,6 +1737,8 @@ map_action_e game_t::make_dialog_choice(hero_t* hero, interactable_object_t* obj
 					give_hero_xp(hero, reward.magnitude);
 					break;
 				}
+				default:
+					break;
 			}
 		}
 		
@@ -2312,7 +2316,7 @@ bool game_t::setup_scripting() {
 	return true;
 }
 
-hero_t game_t::generate_new_recruitable_hero(const player_t& player) {
+hero_t game_t::generate_new_recruitable_hero(const player_t&) {
 	std::vector<hero_t> heroes;
 	for(auto& h : game_config::get_heroes()) {
 		bool conflict = false;
@@ -2361,9 +2365,9 @@ hero_class_e get_random_adjacent_class(hero_class_e hclass) {
 			return (rand() % 2 == 1) ? HERO_CLASS_WARLOCK : HERO_CLASS_BARBARIAN;
 		case HERO_CLASS_BARBARIAN:
 			return (rand() % 2 == 1) ? HERO_CLASS_WARLOCK : HERO_CLASS_NECROMANCER;
+		default:
+			return HERO_CLASS_KNIGHT;
 	}
-
-	return HERO_CLASS_KNIGHT;
 }
 
 const std::vector<hero_class_e>& get_all_hero_classes() {
@@ -2611,7 +2615,7 @@ hero_t* game_t::recruit_hero_at_town(player_e player, int selection, town_t* tow
 		return nullptr;	
 	
 	auto& pl = get_player(player);
-	if(selection >= pl.heroes_available_to_recruit.size())
+	if(selection < 0 || selection >= std::ssize(pl.heroes_available_to_recruit))
 		return nullptr;
 
 	hero_t new_hero = pl.heroes_available_to_recruit[selection];
@@ -2666,7 +2670,6 @@ bool game_t::build_building(town_t* town, building_e building_id) {
 	//move this
 	if(building_id == BUILDING_MAGE_GUILD_1 || building_id == BUILDING_MAGE_GUILD_2 || building_id == BUILDING_MAGE_GUILD_3 || building_id == BUILDING_MAGE_GUILD_4 || building_id == BUILDING_MAGE_GUILD_5) {
 		for(auto sp : town->mage_guild_spells) {
-			auto& spell = game_config::get_spell(sp);
 			if(town->garrisoned_hero && town->garrisoned_hero->can_learn_spell(sp))
 				town->garrisoned_hero->learn_spell(sp);
 				
@@ -2810,11 +2813,13 @@ uint game_t::save_game(const std::string& filename) {
 		header.last_save_time = QDateTime::currentDateTime();
 		
 		//seek back to the start of the file, then write the updated header
-		auto res = file.seek(0);
+		if(!file.seek(0))
+			return 1;
 		write_save_game_header_stream(stream, header);
 
 		//append the save point info
-		res = file.seek(file.size());
+		if(!file.seek(file.size()))
+			return 1;
 		stream << date;
 		stream << (uint16_t)map.heroes.size();
 		for(const auto& hero : map.heroes) {
@@ -2890,6 +2895,8 @@ uint game_t::load_saved_game_info(QDataStream& stream, save_game_header_t& heade
 	//fixme: this is likely broken
 	map_file_header_t map_file_header;
 	auto err = read_map_file_stream(stream, game_info->map, map_file_header);
+	if(err != SUCCESS)
+		return err;
 	
 	//we create an initial save-point which contains the initial game data
 	save_checkpoint_t checkpoint;
@@ -2930,7 +2937,6 @@ uint game_t::load_saved_game_info(QDataStream& stream, save_game_header_t& heade
 		for(int n = 0; n < hero_count; n++) {
 			hero_t hero;
 			stream >> hero;
-			auto id = hero.id;
 			chkpt.heroes.push_back(hero);
 		}
 		

--- a/game/src/core/game_config.cpp
+++ b/game/src/core/game_config.cpp
@@ -187,7 +187,7 @@ int game_config::load_object_data(const std::string& path_prefix) {
 	/////////
 	return 0;
 	
-	for(int i = 0; i < magic_enum::enum_count<interactable_object_e>(); i++) {
+	for(std::size_t i = 0; i < magic_enum::enum_count<interactable_object_e>(); i++) {
 		auto type = (interactable_object_e)i;
 		object_info_t info;
 		info.interactable_object_type = type;

--- a/game/src/core/hero.cpp
+++ b/game/src/core/hero.cpp
@@ -230,6 +230,8 @@ stat_distribution_t hero_t::get_stat_distribution_for_class(hero_class_e hero_cl
 		
 		case HERO_CLASS_CUSTOM:
 			break;
+		default:
+			break;
 	}
 	
 	
@@ -608,7 +610,7 @@ bool hero_t::does_artifact_fit_in_slot(artifact_slot_e artifact_slot, uint hero_
 }
 
 bool hero_t::is_backpack_full() const {
-	for(int i = 0; i < backpack.size(); i++) {
+	for(std::size_t i = 0; i < backpack.size(); i++) {
 		if(backpack[i] == ARTIFACT_NONE)
 			return false;
 	}
@@ -987,7 +989,7 @@ void hero_t::init_talents() {
 		if(t.hero_class != hero_class)
 			continue;
 		
-		if(selected[t.tier].size() >= tier_size[t.tier])
+		if(std::ssize(selected[t.tier]) >= tier_size[t.tier])
 			continue;
 		
 		//prevent duplicates
@@ -1016,7 +1018,7 @@ bool talent_valid(talent_e talent) {
 
 bool hero_t::is_talent_unlocked(talent_e talent_id) const {
 	int pos = -1;
-	for(int i = 0; i < available_talents.size(); i++) {
+	for(std::size_t i = 0; i < available_talents.size(); i++) {
 		if(available_talents[i] == talent_id)
 			pos = i;
 	}
@@ -1332,7 +1334,6 @@ bool hero_t::is_inventory_full(artifact_e artifact_id) const {
 			return false;
 	}
 	
-	int open_slot = -1;//backpack.get_next_open_slot()
 	for(uint i = 0; i < game_config::HERO_BACKPACK_SLOTS; i++) {
 		if(backpack[i] == ARTIFACT_NONE)
 			return false;
@@ -1595,8 +1596,7 @@ uint hero_t::get_unit_initiative(unit_type_e unit_type) const {
 	return initiative;
 }
 
-int hero_t::get_unit_luck(unit_type_e unit_type) const {
-	const auto& creature = game_config::get_creature(unit_type);
+int hero_t::get_unit_luck(unit_type_e) const {
 	int luck = get_luck();
 
 	return luck;
@@ -1688,7 +1688,7 @@ stat_e hero_t::level_up_stats() {
 
 int get_class_learnrate(const skill_t& skill, hero_class_e hero_class) {
 	auto index = (std::countr_zero((uint16_t)hero_class) - 1);
-	if(index < 0 || index >= skill.class_learnrate.size())
+	if(index < 0 || index >= std::ssize(skill.class_learnrate))
 		return 5;
 
 	return skill.class_learnrate[index];

--- a/game/src/core/lua_api.cpp
+++ b/game/src/core/lua_api.cpp
@@ -135,52 +135,49 @@ namespace lua {
 	}
 
 	//hero-related functions
-	int SetHeroName(lua_State* L) {
+	int SetHeroName(lua_State*) {
 		// Implement the functionality to set the hero's name
 		return 0;
 	}
 
-	int SetHeroClass(lua_State* L) {
+	int SetHeroClass(lua_State*) {
 		// Implement the functionality to set the hero's class
 		return 0;
 	}
 
-	int SetHeroLevel(lua_State* L) {
+	int SetHeroLevel(lua_State*) {
 		// Implement the functionality to set the hero's level
 		return 0;
 	}
 
-	int AddHeroExperience(lua_State* L) {
+	int AddHeroExperience(lua_State*) {
 		// Implement the functionality to add experience points to the hero
 		return 0;
 	}
 
-	int LearnSkill(lua_State* L) {
+	int LearnSkill(lua_State*) {
 		// Implement the functionality to make the hero learn a specific skill at a certain level
 		return 0;
 	}
 
-	int UnlearnSkill(lua_State* L) {
+	int UnlearnSkill(lua_State*) {
 		// Implement the functionality to make the hero unlearn a specific skill
 		return 0;
 	}
 
-	int UpgradeSkill(lua_State* L) {
+	int UpgradeSkill(lua_State*) {
 		// Implement the functionality to upgrade a specific skill of the hero to a certain level
 		return 0;
 	}
 
-	int GiveHeroArtifact(lua_State* L) {
+	int GiveHeroArtifact(lua_State*) {
 		// Implement the functionality to give a specific artifact to the hero
 		return 0;
 	}
 
 
-	int SendPlayerConsoleMessage(lua_State* L) {
+	int SendPlayerConsoleMessage(lua_State*) {
 		if(!_game) return 0;
-		
-		auto player = lua_tonumber(L,1);
-		auto message = lua_tostring(L, 2);
 		
 		//if(message)
 		//	std::cout << "console message from lua: " << message << std::endl;
@@ -188,13 +185,8 @@ namespace lua {
 		return 1;
 	}
 
-	int ShowPlayerMessage(lua_State* L) {
+	int ShowPlayerMessage(lua_State*) {
 		if(!_game) return 0;
-		
-		auto player = lua_tonumber(L,1);
-		auto message = lua_tostring(L, 2);
-		auto resource_type = lua_tonumber(L,2);
-		auto amount = lua_tonumber(L,3);
 		return 1;
 	}
 

--- a/game/src/core/map_file.cpp
+++ b/game/src/core/map_file.cpp
@@ -308,7 +308,7 @@ map_error_e read_map_file_stream(QDataStream& stream, adventure_map_t& map, map_
 
 		int player = hero.player;
 		player--;
-		if(player >= 0 && player < map.player_configurations.size()) {
+		if(player >= 0 && player < std::ssize(map.player_configurations)) {
 			if(map.player_configurations[player].starting_hero_id == -1) {
 				map.player_configurations[player].starting_hero_id = hero.id;
 				map.player_configurations[player].is_hero_set_by_map = true;

--- a/game/src/core/town.cpp
+++ b/game/src/core/town.cpp
@@ -250,7 +250,7 @@ void town_t::new_week(bool affected_by_freelancer, bool affected_by_call_to_arms
 	
 }
 
-resource_group_t town_t::get_daily_income(int day) {	
+resource_group_t town_t::get_daily_income(int) {
 	resource_group_t income;
 	income.set_value_for_type(RESOURCE_GOLD, 1000);
 	
@@ -521,7 +521,7 @@ void town_t::populate_available_spells(uint level) {
 	
 	int count = 6 - level;
 	// Select required number of spells for each tier
-	if(spells.size() < count)
+	if(std::ssize(spells) < count)
 		return;
 	
 	int i = 0;
@@ -611,11 +611,11 @@ void town_t::setup_buildings() {
 	allowed_spells.erase(it, allowed_spells.end());
 }
 
-std::string building_t::get_name(building_e type) {
+std::string building_t::get_name(building_e) {
 	return "TODO";
 }
 
-std::string building_t::get_description(building_e type) {
+std::string building_t::get_description(building_e) {
 	return "TODO";
 }
 
@@ -651,10 +651,9 @@ building_e building_t::get_parent_building(building_e type) {
 //	return reqs;
 //}
 
-resource_group_t building_t::get_cost(building_e type) {
+resource_group_t building_t::get_cost(building_e) {
 	resource_group_t res;
 	res.set_value_for_type(RESOURCE_GOLD, 2000);
 	
 	return res;
 }
-


### PR DESCRIPTION
### Motivation
- Reduce compiler warnings and potential undefined behavior by addressing unused parameters and missing `default` cases in switches.
- Replace signed/unsigned and container-size comparisons with safer `std::ssize`/`size_t` usages to avoid out-of-bounds checks and implicit conversions.
- Harden I/O operations (e.g. `QFile::seek`) and ensure functions return or noop appropriately for unhandled branches.
- Improve code clarity and consistency across multiple core game modules (map, battlefield, game logic, AI, lua API, config, etc.).

### Description
- Removed or ignored unused function parameters by updating signatures (e.g. `get_route_ignoring_blockables`, `write_battlefield_to_stream`, various `cast_spell`/`get_time_to_tile`/`generate_new_recruitable_hero` functions) to silence warnings and clarify intent.
- Replaced various index/size comparisons and loop counters with `std::ssize`, `std::size_t`, or explicit `static_cast<int>` checks to prevent signed/unsigned mismatches and improve safety when comparing to container sizes.
- Added `default` branches or `break` handling in multiple `switch` statements to avoid falling through and to make code paths explicit (AI pickups, battlefield stringification, game interactions, lua stubs, etc.).
- Added validation for file seek results in `save_game` to handle I/O failures and return errors early.
- Miscellaneous small fixes: return type/parameter cleanup in several functions, replaced unused local variables, and minor refactors in loops and conditionals across many source files.

### Testing
- Built the project with the standard build (`cmake` / `cmake --build .`) to verify compilation after changes, and the build completed successfully.
- Ran the test runner (`ctest`) where available; existing automated tests completed without failures.
- Performed static analysis / warning checks to confirm the targeted compiler warnings (unused params, signed/unsigned comparisons) were addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ef135eaac832d8bd132c2849089ac)