### PR TITLE
Expand combat achievement tests with concrete spell and melee scenarios

### DIFF
--- a/achievements_tests_progress.txt
+++ b/achievements_tests_progress.txt
@@ -18,10 +18,12 @@ Adventure map / economy / progression tests implemented:
 - Generic achievement config validation, callback firing, threshold crossing, and one-shot semantics.
 
 Combat tests implemented:
-- ACHIEVEMENT_STORM_DRINKER has a concrete spell-cast scenario: a hero casts SPELL_LIGHTNING_BOLT against enemy troops, lightning damage is recorded, battle results are accepted, and the achievement callback is asserted.
+- The elemental spell-damage Magic achievements now have concrete spell-cast scenarios: In Flames (Fire Ball), Winter Is Coming (Frost Ray), Storm Drinker (Lightning Bolt), Earthshaker (Meteor Shower), Chaos Theory (Death Coil), and Blinded by the Light (Holy Shout). Each scenario casts through battlefield_t::cast_spell(), verifies typed damage stats, accepts battle results, and asserts callback progress.
+- Additional Magic achievements now have concrete combat scenarios: I Dream of Genie, Friendly Fire, Brains Beats Brawn, Quenching the Flame, Meteoric Rise, Grave Mistake, Creative Caster, Watch the World Burn, and Master of the Arcane.
 - All configured ACHIEVEMENT_TYPE_MAGIC achievements have explicit test cases.
 - All configured ACHIEVEMENT_TYPE_MIGHT achievements have explicit test cases.
 - Magic and Might combat-stat achievements are tested through battlefield_t/game_t::battle stats and game_t::accept_battle_results().
+- Additional Might achievements now have concrete combat scenarios: The Reaper, One Punch Hero, Shot Through the Heart, Titanic Smackdown, The Bigger They Are..., Unbreakable, High Roller, Maximum Overkill, and Crunching Numbers.
 - Magic and Might event achievements are tested through battlefield_t/game_t::battle conditions and game_t::accept_battle_results() where a gameplay combat-result path exists.
 
 Known passing state
@@ -37,8 +39,7 @@ Known failing achievement tests
 Still needs implementing / improving
 ------------------------------------
 - Replace remaining synthetic combat-stat/event setup with concrete battlefield actions for each Magic and Might achievement where practical, similar to the new Storm Drinker Lightning Bolt scenario.
-- Add concrete spell-cast scenarios for the remaining elemental damage achievements: In Flames, Winter Is Coming, Earthshaker, Chaos Theory, and Blinded by the Light.
-- Add concrete scenarios for special Magic achievements such as Friendly Fire, Quenching the Flame, Conductive Critters, Meteoric Rise, Grave Mistake, Second Life, Creative Caster, Watch the World Burn, Master of the Arcane, and Energizer Bunny.
-- Add concrete combat-action scenarios for Might achievements such as Shot Through the Heart, Titanic Smackdown, The Bigger They Are..., Unbreakable, Outlast, High Roller, Maximum Overkill, and Crunching Numbers.
+- Add concrete scenarios for remaining special Magic achievements where gameplay support is practical: Conductive Critters, Second Life, and Energizer Bunny.
+- Add concrete combat-action scenarios for remaining Might achievements where gameplay support is practical: Outlast and other win-condition/stat-only Might achievements.
 - ACHIEVEMENT_TURTLING_UP currently has no live combat-result stat path in the core gameplay code; it is covered for achievement progress semantics but still needs gameplay implementation before a true battlefield scenario can be tested.
 - ACHIEVEMENT_ANCIENT_SECRETS is combat-adjacent via Pyramid battle rewards and is covered for progress semantics; a fuller integration test should drive a Pyramid battle reward flow.

--- a/tests/combat_achievement_tests.cpp
+++ b/tests/combat_achievement_tests.cpp
@@ -30,6 +30,13 @@ struct small_might_combat_stat_achievement_case_t {
         achievement_e achievement;
 };
 
+struct elemental_spell_damage_achievement_case_t {
+        spell_e spell;
+        unit_type_e target_unit;
+        uint32_t combat_stats_t::* stat;
+        achievement_e achievement;
+};
+
 void expect_true(bool condition, const std::string& message) {
         if(!condition) {
                 std::cerr << "FAIL: " << message << '\n';
@@ -67,6 +74,17 @@ battlefield_unit_t make_battlefield_unit(unit_type_e type, uint16_t stack_size, 
 
 void place_battlefield_unit(battlefield_t& battlefield, battlefield_unit_t& unit) {
         battlefield.hex_grid.get_hex(unit.x, unit.y)->unit = &unit;
+}
+
+std::vector<elemental_spell_damage_achievement_case_t> elemental_spell_damage_achievement_cases() {
+        return {
+                {SPELL_FIRE_BALL, UNIT_SKELETON, &combat_stats_t::fire_spell_damage, ACHIEVEMENT_IN_FLAMES},
+                {SPELL_FROST_RAY, UNIT_EFREETI, &combat_stats_t::frost_spell_damage, ACHIEVEMENT_WINTER_IS_COMING},
+                {SPELL_LIGHTNING_BOLT, UNIT_SKELETON, &combat_stats_t::lightning_spell_damage, ACHIEVEMENT_STORM_DRINKER},
+                {SPELL_METEOR_SHOWER, UNIT_SKELETON, &combat_stats_t::earth_spell_damage, ACHIEVEMENT_EARTHSHAKER},
+                {SPELL_DEATH_COIL, UNIT_SKELETON, &combat_stats_t::chaos_spell_damage, ACHIEVEMENT_CHAOS_THEORY},
+                {SPELL_HOLY_SHOUT, UNIT_SKELETON, &combat_stats_t::holy_spell_damage, ACHIEVEMENT_BLINDED_BY_THE_LIGHT},
+        };
 }
 
 std::vector<small_magic_combat_stat_achievement_case_t> small_magic_combat_stat_achievement_cases() {
@@ -155,7 +173,7 @@ void initialize_combat_achievement_game(game_t& game, hero_t& attacker, player_t
 void apply_magic_event_condition(game_t& game, hero_t& attacker, achievement_e achievement) {
         switch(achievement) {
                 case ACHIEVEMENT_FRIENDLY_FIRE:
-                        game.battle.result = BATTLE_ATTACKER_VICTORY;
+                game.battle.result = BATTLE_ATTACKER_VICTORY;
                         game.battle.attacker_stats.friendly_fire_spell_hits = 1;
                         game.battle.attacker_stats.total_units_lost = 1;
                         break;
@@ -287,43 +305,315 @@ void apply_might_event_condition(game_t& game, hero_t& attacker, hero_t& defende
         }
 }
 
-void test_storm_drinker_lightning_spell_damage_cast_progress_and_callback() {
+void test_elemental_spell_damage_cast_progress_and_callbacks() {
+        for(const auto& test_case : elemental_spell_damage_achievement_cases()) {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+
+                attacker.power = 200;
+                attacker.mana = 1000;
+                attacker.spellbook.push_back(test_case.spell);
+
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(test_case.target_unit, 1000, false, 1, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) {
+                        earned.push_back(achievement);
+                };
+
+                const auto first_threshold = first_threshold_or_one(game_config::get_achievement(test_case.achievement));
+                auto& progress = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.*(test_case.stat);
+                progress = 0;
+
+                expect_true(game.battle.cast_spell(&attacker, test_case.spell, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            game_config::get_achievement(test_case.achievement).name + " spell scenario should cast successfully");
+                const auto spell_damage = game.battle.attacker_stats.*(test_case.stat);
+                expect_true(spell_damage > 0,
+                            game_config::get_achievement(test_case.achievement).name + " spell scenario should record typed spell damage");
+
+                progress = first_threshold > spell_damage ? first_threshold - spell_damage : 0;
+                const auto expected_progress = progress + spell_damage;
+                game.accept_battle_results();
+
+                expect_eq(progress, expected_progress,
+                          game_config::get_achievement(test_case.achievement).name + " should add actual cast spell damage to cumulative typed spell damage");
+                expect_eq(earned_count(earned, test_case.achievement), size_t(1),
+                          game_config::get_achievement(test_case.achievement).name + " callback should fire exactly once after a concrete spell cast crosses the first tier threshold");
+                expect_true(!earned.empty(),
+                            game_config::get_achievement(test_case.achievement).name + " concrete spell scenario should fire an achievement callback");
+        }
+}
+
+void set_achievement_event_progress_to_before_first_tier(game_t& game, achievement_e achievement) {
+        const auto first_threshold = first_threshold_or_one(game_config::get_achievement(achievement));
+        game.get_player(PLAYER_1).player_stats.achievement_event_counts[achievement] = first_threshold - 1;
+}
+
+void expect_concrete_magic_event_callback(const std::vector<achievement_e>& earned, achievement_e achievement) {
+        expect_eq(earned_count(earned, achievement), size_t(1),
+                  game_config::get_achievement(achievement).name + " concrete combat scenario should fire exactly one callback");
+}
+
+void test_i_dream_of_genie_unit_spellcast_progress_and_callback() {
         game_t game;
         hero_t attacker;
         player_t player;
         initialize_combat_achievement_game(game, attacker, player);
 
-        attacker.power = 200;
-        attacker.mana = 1000;
-        attacker.spellbook.push_back(SPELL_LIGHTNING_BOLT);
-
-        auto& target = game.battle.defending_army.troops[0];
-        target = make_battlefield_unit(UNIT_SKELETON, 1000, false, 1, 8, 5);
-        place_battlefield_unit(game.battle, target);
+        game.battle.attacking_army.hero = &attacker;
+        auto& genie = game.battle.attacking_army.troops[0];
+        genie = make_battlefield_unit(UNIT_GENIE, 1, true, 1, 3, 5);
+        genie.spell_casts_remaining = 1;
+        place_battlefield_unit(game.battle, genie);
+        auto& ally = game.battle.attacking_army.troops[1];
+        ally = make_battlefield_unit(UNIT_INFANTRYMAN, 10, true, 2, 4, 5);
+        place_battlefield_unit(game.battle, ally);
 
         std::vector<achievement_e> earned;
         game.achievement_earned_callback_fn = [&](achievement_e achievement) {
                 earned.push_back(achievement);
         };
 
-        const auto first_threshold = first_threshold_or_one(game_config::get_achievement(ACHIEVEMENT_STORM_DRINKER));
-        auto& progress = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.lightning_spell_damage;
+        const auto first_threshold = first_threshold_or_one(game_config::get_achievement(ACHIEVEMENT_I_DREAM_OF_GENIE));
+        auto& progress = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.genie_friendly_spells_cast;
         progress = first_threshold - 1;
 
-        expect_true(game.battle.cast_spell(&attacker, SPELL_LIGHTNING_BOLT, target.x, target.y, &target) == SPELL_RESULT_OK,
-                    "Lightning Bolt should successfully hit the enemy stack in the Storm Drinker scenario");
-        expect_true(game.battle.attacker_stats.lightning_spell_damage > 0,
-                    "Lightning Bolt should record lightning spell damage for the attacking hero");
+        expect_true(game.battle.cast_spell(&genie, SPELL_BLESS, ally.x, ally.y, &ally) == SPELL_RESULT_OK,
+                    "Genie should successfully cast a friendly Bless spell");
+        expect_eq(game.battle.attacker_stats.genie_friendly_spells_cast, static_cast<uint16_t>(1),
+                  "Genie friendly spellcast should be recorded on attacker combat stats");
 
-        const auto lightning_damage = game.battle.attacker_stats.lightning_spell_damage;
         game.accept_battle_results();
 
-        expect_eq(progress, first_threshold - 1 + lightning_damage,
-                  "Storm Drinker should add actual Lightning Bolt damage to cumulative lightning spell damage");
-        expect_eq(earned_count(earned, ACHIEVEMENT_STORM_DRINKER), size_t(1),
-                  "Storm Drinker callback should fire exactly once after Lightning Bolt crosses the first tier threshold");
-        expect_true(!earned.empty(),
-                    "Lightning Bolt scenario should fire at least the Storm Drinker achievement callback");
+        expect_eq(progress, first_threshold,
+                  "I Dream of Genie should add the concrete Genie spellcast to cumulative progress");
+        expect_eq(earned_count(earned, ACHIEVEMENT_I_DREAM_OF_GENIE), size_t(1),
+                  "I Dream of Genie concrete spellcast should fire exactly one callback");
+}
+
+void test_special_magic_achievement_concrete_spell_scenarios() {
+        {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+                game.battle.result = BATTLE_ATTACKER_VICTORY;
+                attacker.power = 200;
+                attacker.mana = 1000;
+                attacker.spellbook.push_back(SPELL_METEOR_SHOWER);
+
+                auto& ally = game.battle.attacking_army.troops[0];
+                ally = make_battlefield_unit(UNIT_INFANTRYMAN, 1000, true, 1, 7, 5);
+                place_battlefield_unit(game.battle, ally);
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(UNIT_SKELETON, 1000, false, 2, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_FRIENDLY_FIRE);
+
+                expect_true(game.battle.cast_spell(&attacker, SPELL_METEOR_SHOWER, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Meteor Shower should successfully hit both enemy and adjacent friendly stacks");
+                expect_true(game.battle.attacker_stats.friendly_fire_spell_hits > 0,
+                            "Meteor Shower should record friendly-fire spell hits");
+                game.accept_battle_results();
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_FRIENDLY_FIRE);
+        }
+
+        {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+                game.battle.result = BATTLE_ATTACKER_VICTORY;
+                attacker.power = 200;
+                attacker.mana = 1000;
+                attacker.spellbook.push_back(SPELL_LIGHTNING_BOLT);
+
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(UNIT_SKELETON, 1000, false, 1, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_BRAINS_BEATS_BRAWN);
+
+                expect_true(game.battle.cast_spell(&attacker, SPELL_LIGHTNING_BOLT, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Lightning Bolt should successfully deal spell-only combat damage");
+                expect_true(game.battle.attacker_stats.total_spell_damage_done > 0,
+                            "Lightning Bolt should record spell damage for the attacker");
+                expect_eq(game.battle.attacker_stats.total_physical_damage_done, static_cast<uint64_t>(0),
+                          "Spell-only victory scenario should not record physical damage");
+                game.accept_battle_results();
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_BRAINS_BEATS_BRAWN);
+        }
+
+        {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+                attacker.power = 200;
+                attacker.mana = 1000;
+                attacker.spellbook.push_back(SPELL_FROST_RAY);
+
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(UNIT_EFREETI, 1, false, 1, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_QUENCHING_THE_FLAME);
+
+                expect_true(game.battle.cast_spell(&attacker, SPELL_FROST_RAY, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Frost Ray should successfully target a Fire-immune Efreeti stack");
+                expect_eq(game.battle.attacker_stats.frost_kill_fire_immune, static_cast<uint16_t>(1),
+                          "Frost Ray should record killing a Fire-immune stack with Frost damage");
+                game.accept_battle_results();
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_QUENCHING_THE_FLAME);
+        }
+
+        {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+                attacker.power = 200;
+                attacker.mana = 1000;
+                attacker.spellbook.push_back(SPELL_METEOR_SHOWER);
+
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(UNIT_SKELETON, 75, false, 1, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_METEORIC_RISE);
+
+                expect_true(game.battle.cast_spell(&attacker, SPELL_METEOR_SHOWER, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Meteor Shower should successfully hit a 75-unit enemy stack");
+                expect_eq(game.battle.attacker_stats.meteor_shower_75kills, static_cast<uint16_t>(1),
+                          "Meteor Shower should record killing at least 75 units in one cast");
+                game.accept_battle_results();
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_METEORIC_RISE);
+        }
+
+        {
+                game_t game;
+                hero_t attacker;
+                hero_t defender;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+                defender.hero_class = HERO_CLASS_NECROMANCER;
+                game.battle.defending_hero = &defender;
+                attacker.power = 200;
+                attacker.mana = 1000;
+                attacker.spellbook.push_back(SPELL_IMPLOSION);
+
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(UNIT_SKELETON, 1, false, 1, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_GRAVE_MISTAKE);
+
+                expect_true(game.battle.cast_spell(&attacker, SPELL_IMPLOSION, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Implosion should successfully kill the Necromancer defender's last stack");
+                expect_eq(game.battle.attacker_stats.implosion_finish_necromancer, static_cast<uint16_t>(1),
+                          "Implosion should record finishing off a Necromancer hero");
+                game.accept_battle_results();
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_GRAVE_MISTAKE);
+        }
+
+
+        {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+                attacker.power = 10;
+                attacker.mana = 1000;
+                attacker.spellbook = {SPELL_SWIFTNESS, SPELL_ARCANE_BOLT, SPELL_BLESS, SPELL_FIRE_BALL, SPELL_DEATH_COIL, SPELL_SLOW};
+
+                auto& ally = game.battle.attacking_army.troops[0];
+                ally = make_battlefield_unit(UNIT_INFANTRYMAN, 1000, true, 1, 3, 5);
+                place_battlefield_unit(game.battle, ally);
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(UNIT_SKELETON, 10000, false, 2, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_CREATIVE_CASTER);
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_MASTER_OF_THE_ARCANE);
+
+                expect_true(game.battle.cast_spell(&attacker, SPELL_SWIFTNESS, ally.x, ally.y, &ally) == SPELL_RESULT_OK,
+                            "Swiftness should cast as the Nature school spell");
+                game.battle.attacking_hero_used_cast = false;
+                expect_true(game.battle.cast_spell(&attacker, SPELL_ARCANE_BOLT, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Arcane Bolt should cast as the Arcane school spell");
+                game.battle.attacking_hero_used_cast = false;
+                expect_true(game.battle.cast_spell(&attacker, SPELL_BLESS, ally.x, ally.y, &ally) == SPELL_RESULT_OK,
+                            "Bless should cast as the Holy school spell");
+                game.battle.attacking_hero_used_cast = false;
+                expect_true(game.battle.cast_spell(&attacker, SPELL_FIRE_BALL, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Fire Ball should cast as the Destruction school spell");
+                game.battle.attacking_hero_used_cast = false;
+                expect_true(game.battle.cast_spell(&attacker, SPELL_DEATH_COIL, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Death Coil should cast as the Death school spell");
+                game.battle.attacking_hero_used_cast = false;
+                expect_true(game.battle.cast_spell(&attacker, SPELL_SLOW, target.x, target.y, &target) == SPELL_RESULT_OK,
+                            "Slow should cast as a sixth unique spell");
+                expect_eq(game.battle.attacker_stats.unique_spells_cast, static_cast<uint16_t>(6),
+                          "Six distinct concrete spell casts should be recorded");
+                expect_eq(game.battle.attacker_stats.total_spells_cast_nature, static_cast<uint16_t>(1),
+                          "Nature spell cast should be recorded");
+                expect_eq(game.battle.attacker_stats.total_spells_cast_arcane, static_cast<uint16_t>(2),
+                          "Arcane spell casts should be recorded");
+                expect_eq(game.battle.attacker_stats.total_spells_cast_holy, static_cast<uint16_t>(1),
+                          "Holy spell cast should be recorded");
+                expect_eq(game.battle.attacker_stats.total_spells_cast_destruction, static_cast<uint16_t>(1),
+                          "Destruction spell cast should be recorded");
+                expect_eq(game.battle.attacker_stats.total_spells_cast_death, static_cast<uint16_t>(1),
+                          "Death spell cast should be recorded");
+                game.accept_battle_results();
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_CREATIVE_CASTER);
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_MASTER_OF_THE_ARCANE);
+        }
+
+        {
+                game_t game;
+                hero_t attacker;
+                player_t player;
+                initialize_combat_achievement_game(game, attacker, player);
+                attacker.power = 200;
+                attacker.mana = 1000;
+                attacker.spellbook.push_back(SPELL_ARMAGEDDON);
+
+                auto& ally = game.battle.attacking_army.troops[0];
+                ally = make_battlefield_unit(UNIT_INFANTRYMAN, 1000, true, 1, 3, 5);
+                place_battlefield_unit(game.battle, ally);
+                auto& target = game.battle.defending_army.troops[0];
+                target = make_battlefield_unit(UNIT_SKELETON, 1000, false, 2, 8, 5);
+                place_battlefield_unit(game.battle, target);
+
+                std::vector<achievement_e> earned;
+                game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+                set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_WATCH_THE_WORLD_BURN);
+
+                expect_true(game.battle.cast_spell(&attacker, SPELL_ARMAGEDDON) == SPELL_RESULT_OK,
+                            "Armageddon should successfully hit battlefield units");
+                expect_eq(game.battle.attacker_stats.armageddon_5000_damage, static_cast<uint16_t>(1),
+                          "Armageddon should record dealing at least 5000 damage in one cast");
+                game.accept_battle_results();
+                expect_concrete_magic_event_callback(earned, ACHIEVEMENT_WATCH_THE_WORLD_BURN);
+        }
 }
 
 template<typename TestCase>
@@ -411,6 +701,192 @@ void test_all_magic_achievements_have_specific_test_case() {
 }
 
 
+void prepare_adjacent_melee_attack(game_t& game, hero_t& attacker_hero, battlefield_unit_t& attacker, battlefield_unit_t& defender) {
+        game.battle.attacking_army.hero = &attacker_hero;
+        game.battle.defending_army.hero = nullptr;
+        place_battlefield_unit(game.battle, attacker);
+        place_battlefield_unit(game.battle, defender);
+}
+
+void test_reaper_one_punch_and_titanic_smackdown_concrete_melee_attack() {
+        game_t game;
+        hero_t attacker_hero;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker_hero, player);
+
+        auto& attacker = game.battle.attacking_army.troops[0];
+        attacker = make_battlefield_unit(UNIT_TITAN, 1000, true, 1, 7, 5);
+        auto& defender = game.battle.defending_army.troops[0];
+        defender = make_battlefield_unit(UNIT_SKELETON, 1, false, 2, 8, 5);
+        prepare_adjacent_melee_attack(game, attacker_hero, attacker, defender);
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+
+        auto& cumulative = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats;
+        cumulative.total_units_killed = first_threshold_or_one(game_config::get_achievement(ACHIEVEMENT_THE_REAPER)) - 1;
+        cumulative.max_damage_single_melee_attack = 0;
+        set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_TITANIC_SMACKDOWN);
+        set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_MAXIMUM_OVERKILL);
+
+        expect_true(game.battle.attack_unit(attacker, &defender, false, attacker.x, attacker.y),
+                    "Titan should successfully make a concrete adjacent melee attack");
+        expect_eq(game.battle.attacker_stats.total_units_killed, static_cast<uint32_t>(1),
+                  "Titan melee attack should record one killed unit");
+        expect_true(game.battle.attacker_stats.max_damage_single_melee_attack >= 5000,
+                    "Titan melee attack should record at least 5000 melee damage");
+        expect_eq(game.battle.attacker_stats.titanic_smackdowns, static_cast<uint16_t>(1),
+                  "Titan melee attack should record a Titanic Smackdown event");
+        expect_eq(game.battle.attacker_stats.maximum_overkill_hits, static_cast<uint16_t>(1),
+                  "Titan melee attack should record a Maximum Overkill event");
+
+        const auto expected_one_punch_progress = game.battle.attacker_stats.max_damage_single_melee_attack;
+        game.accept_battle_results();
+
+        expect_eq(cumulative.total_units_killed, first_threshold_or_one(game_config::get_achievement(ACHIEVEMENT_THE_REAPER)),
+                  "The Reaper should add concrete melee kills to cumulative progress");
+        expect_eq(cumulative.max_damage_single_melee_attack, expected_one_punch_progress,
+                  "One Punch Hero should store the concrete melee attack's damage");
+        expect_eq(earned_count(earned, ACHIEVEMENT_THE_REAPER), size_t(1),
+                  "The Reaper concrete melee attack should fire exactly one callback");
+        expect_eq(earned_count(earned, ACHIEVEMENT_ONE_PUNCH_HERO), size_t(1),
+                  "One Punch Hero concrete melee attack should fire exactly one callback");
+        expect_eq(earned_count(earned, ACHIEVEMENT_TITANIC_SMACKDOWN), size_t(1),
+                  "Titanic Smackdown concrete melee attack should fire exactly one callback");
+        expect_eq(earned_count(earned, ACHIEVEMENT_MAXIMUM_OVERKILL), size_t(1),
+                  "Maximum Overkill concrete melee attack should fire exactly one callback");
+}
+
+void test_bigger_they_are_concrete_tier1_melee_kill() {
+        game_t game;
+        hero_t attacker_hero;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker_hero, player);
+
+        auto& attacker = game.battle.attacking_army.troops[0];
+        attacker = make_battlefield_unit(UNIT_INFANTRYMAN, 1000, true, 1, 7, 5);
+        auto& defender = game.battle.defending_army.troops[0];
+        defender = make_battlefield_unit(UNIT_BEHEMOTH, 1, false, 2, 8, 5);
+        prepare_adjacent_melee_attack(game, attacker_hero, attacker, defender);
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+        set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_THE_BIGGER_THEY_ARE);
+
+        expect_true(game.battle.attack_unit(attacker, &defender, false, attacker.x, attacker.y),
+                    "Tier-1-only army should successfully make a concrete melee attack against a tier-6 stack");
+        expect_eq(game.battle.attacker_stats.tier6_killed_by_tier1_army, static_cast<uint16_t>(1),
+                  "Tier-1-only melee attack should record killing a tier-6 stack");
+        game.accept_battle_results();
+        expect_eq(earned_count(earned, ACHIEVEMENT_THE_BIGGER_THEY_ARE), size_t(1),
+                  "The Bigger They Are concrete melee attack should fire exactly one callback");
+}
+
+void test_crunching_numbers_concrete_exact_melee_kill() {
+        game_t game;
+        hero_t attacker_hero;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker_hero, player);
+
+        auto& attacker = game.battle.attacking_army.troops[0];
+        attacker = make_battlefield_unit(UNIT_BISHOP, 1, true, 1, 7, 5);
+        auto& defender = game.battle.defending_army.troops[0];
+        defender = make_battlefield_unit(UNIT_SKELETON, 1, false, 2, 8, 5);
+        prepare_adjacent_melee_attack(game, attacker_hero, attacker, defender);
+
+        const auto exact_damage = game.battle.calculate_damage(attacker, defender, false, false);
+        const auto defender_hp = game.battle.get_unit_adjusted_hp(defender);
+        defender.stack_size = static_cast<uint16_t>((exact_damage + defender_hp - 1) / defender_hp);
+        defender.unit_health = exact_damage % defender_hp;
+        if(defender.unit_health == 0)
+                defender.unit_health = defender_hp;
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+        set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_CRUNCHING_NUMBERS);
+
+        expect_true(game.battle.attack_unit(attacker, &defender, false, attacker.x, attacker.y),
+                    "Bishop should successfully make a concrete exact-damage melee attack");
+        expect_eq(game.battle.attacker_stats.exact_melee_kills, static_cast<uint16_t>(1),
+                  "Exact-damage melee attack should record a Crunching Numbers event");
+        game.accept_battle_results();
+        expect_eq(earned_count(earned, ACHIEVEMENT_CRUNCHING_NUMBERS), size_t(1),
+                  "Crunching Numbers concrete melee attack should fire exactly one callback");
+}
+
+void test_shot_through_the_heart_and_high_roller_concrete_ranged_critical() {
+        game_t game;
+        hero_t attacker_hero;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker_hero, player);
+        attacker_hero.skills[0] = {SKILL_LUCK, 5};
+
+        auto& attacker = game.battle.attacking_army.troops[0];
+        attacker = make_battlefield_unit(UNIT_ORC, 10, true, 1, 3, 5);
+        attacker.add_buff(BUFF_INCREASED_LUCK, -1, 255);
+        auto& defender = game.battle.defending_army.troops[0];
+        defender = make_battlefield_unit(UNIT_SKELETON, 100, false, 2, 8, 5);
+        prepare_adjacent_melee_attack(game, attacker_hero, attacker, defender);
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+
+        auto& cumulative = game.get_player(PLAYER_1).player_stats.cumulative_combat_stats.total_critical_hits;
+        cumulative = first_threshold_or_one(game_config::get_achievement(ACHIEVEMENT_SHOT_THROUGH_THE_HEART)) - 1;
+        game.get_player(PLAYER_1).player_stats.achievement_event_counts[ACHIEVEMENT_HIGH_ROLLER] = 0;
+
+        expect_true(game.battle.attack_unit(attacker, &defender, true, attacker.x, attacker.y),
+                    "High-luck Orc should successfully make a concrete ranged attack");
+        expect_eq(game.battle.attacker_stats.total_attacks_made, static_cast<uint16_t>(1),
+                  "Concrete ranged attack should record one attack made");
+        expect_eq(game.battle.attacker_stats.total_critical_hits, static_cast<uint16_t>(1),
+                  "High-luck concrete ranged attack should record one critical hit");
+
+        game.accept_battle_results();
+
+        expect_eq(cumulative, first_threshold_or_one(game_config::get_achievement(ACHIEVEMENT_SHOT_THROUGH_THE_HEART)),
+                  "Shot Through the Heart should add the concrete critical hit to cumulative progress");
+        expect_eq(earned_count(earned, ACHIEVEMENT_SHOT_THROUGH_THE_HEART), size_t(1),
+                  "Shot Through the Heart concrete critical hit should fire exactly one callback");
+        expect_eq(earned_count(earned, ACHIEVEMENT_HIGH_ROLLER), size_t(1),
+                  "High Roller concrete all-critical battle should fire exactly one callback");
+}
+
+void test_unbreakable_concrete_attacks_received() {
+        game_t game;
+        hero_t attacker_hero;
+        player_t player;
+        initialize_combat_achievement_game(game, attacker_hero, player);
+        game.battle.result = BATTLE_ATTACKER_VICTORY;
+
+        auto& attacker = game.battle.attacking_army.troops[0];
+        attacker = make_battlefield_unit(UNIT_CRUSADER, 100, true, 1, 7, 5);
+        auto& defender = game.battle.defending_army.troops[0];
+        defender = make_battlefield_unit(UNIT_SKELETON, 1, false, 2, 8, 5);
+        prepare_adjacent_melee_attack(game, attacker_hero, attacker, defender);
+
+        std::vector<achievement_e> earned;
+        game.achievement_earned_callback_fn = [&](achievement_e achievement) { earned.push_back(achievement); };
+        game.get_player(PLAYER_1).player_stats.achievement_event_counts[ACHIEVEMENT_FLAWLESS_EXECUTION] = 1;
+        set_achievement_event_progress_to_before_first_tier(game, ACHIEVEMENT_UNBREAKABLE);
+
+        for(int i = 0; i < 10; ++i) {
+                defender.stack_size = 1;
+                defender.unit_health = game.battle.get_unit_adjusted_hp(defender);
+                place_battlefield_unit(game.battle, defender);
+                expect_true(game.battle.attack_unit(defender, &attacker, false, defender.x, defender.y),
+                            "Defender should successfully make a concrete melee attack received by the attacker");
+                defender.has_moved = false;
+                defender.has_waited = false;
+        }
+        expect_true(game.battle.attacker_stats.total_attacks_received >= 10,
+                    "Concrete defender attacks should record at least ten attacks received by the attacker");
+
+        game.accept_battle_results();
+        expect_eq(earned_count(earned, ACHIEVEMENT_UNBREAKABLE), size_t(1),
+                  "Unbreakable concrete attacks-received scenario should fire exactly one callback");
+}
+
 template<typename TestCase>
 void test_might_combat_stat_case(const TestCase& test_case) {
         game_t game;
@@ -495,11 +971,18 @@ void test_all_might_achievements_have_specific_test_case() {
 
 int run_combat_achievement_tests() {
         failures = 0;
-        test_storm_drinker_lightning_spell_damage_cast_progress_and_callback();
+        test_elemental_spell_damage_cast_progress_and_callbacks();
+        test_i_dream_of_genie_unit_spellcast_progress_and_callback();
+        test_special_magic_achievement_concrete_spell_scenarios();
         test_magic_combat_stat_progress_and_callbacks();
         test_magic_event_progress_and_callbacks();
         test_all_magic_achievements_have_specific_test_case();
         test_might_combat_stat_progress_and_callbacks();
+        test_reaper_one_punch_and_titanic_smackdown_concrete_melee_attack();
+        test_bigger_they_are_concrete_tier1_melee_kill();
+        test_crunching_numbers_concrete_exact_melee_kill();
+        test_shot_through_the_heart_and_high_roller_concrete_ranged_critical();
+        test_unbreakable_concrete_attacks_received();
         test_might_event_progress_and_callbacks();
         test_all_might_achievements_have_specific_test_case();
         return failures;


### PR DESCRIPTION
### Motivation

- Replace synthetic combat-stat/event setups with concrete battlefield actions for Magic and Might achievements to increase test fidelity.
- Verify that typed spell damage and combat-event stats are recorded by actual `battlefield_t` actions and then propagated to cumulative player stats and achievement callbacks.
- Cover many previously synthetic or missing scenarios (elemental spells, special Magic events, and several Might combat events) with end-to-end concrete tests.

### Description

- Added `elemental_spell_damage_achievement_case_t`, helper builders, and `elemental_spell_damage_achievement_cases()` to drive typed-spell damage scenarios and implemented `test_elemental_spell_damage_cast_progress_and_callbacks()` to replace the single Lightning test.
- Implemented concrete unit-cast and spell scenarios including `test_i_dream_of_genie_unit_spellcast_progress_and_callback()` and `test_special_magic_achievement_concrete_spell_scenarios()` covering many Magic achievements end-to-end.
- Added multiple concrete Might combat scenarios and helpers (melee/ranged/critical/overkill/exact-damage/attacks-received) in new tests such as `test_reaper_one_punch_and_titanic_smackdown_concrete_melee_attack()`, `test_bigger_they_are_concrete_tier1_melee_kill()`, `test_crunching_numbers_concrete_exact_melee_kill()`, `test_shot_through_the_heart_and_high_roller_concrete_ranged_critical()`, and `test_unbreakable_concrete_attacks_received()` as well as helper functions like `prepare_adjacent_melee_attack()` and `set_achievement_event_progress_to_before_first_tier()`.
- Updated the combat test runner to call all new test cases and updated `achievements_tests_progress.txt` to reflect the expanded concrete coverage.

### Testing

- Ran the full achievement test suite locally with `qmake tests/achievement_tests.pro -o /tmp/achievement_tests.Makefile && make -f /tmp/achievement_tests.Makefile -j2` and executed the test binary, which passed.
- `run_combat_achievement_tests()` now executes the new elemental, special-magic, and might concrete scenario tests and they passed in the local test run.
- No automated test failures are currently known in the achievement test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d1c89ef34832d87f38d1d3d944eb7)